### PR TITLE
Resources now return single pages by default for collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A node.js client for the 1.0 version of the Asana API.
 ## Design Decisions
 
 - **Thin Wrapper** This client is a thin wrapper which means that the client
-  makes no attempt to verify the validity of the arguments locally. All errors
+  makes little attempt to verify the validity of the arguments locally. All errors
   are reported by the server. We include custom Error types which will contain
   the response from the server.
 - **Promises** Promises with [bluebird][bluebird] seem like the most neutral way
@@ -18,13 +18,16 @@ A node.js client for the 1.0 version of the Asana API.
 
 ## Examples
 
+Various examples are in the repository under `examples/`, but some basic
+use cases are illustrated here.
+
 ### Find all incomplete tasks assigned to me that are new or marked for today across my workspaces
 
 ```js
 var asana = require('asana');
 var util = require('util');
 
-var client = asana.Client.basicAuth(process.env.ASANA_API_KEY);
+var client = asana.Client.create().useBasicAuth(process.env.ASANA_API_KEY);
 
 client.users.me().then(function(user) {
   return user.workspaces.map(function(workspace) {
@@ -34,6 +37,7 @@ client.users.me().then(function(user) {
     };
   });
 }).map(function(data) {
+  #xcxc this is now broken / different
   return client.tasks.findAll({
     assignee: data.user,
     workspace: data.workspace,
@@ -55,7 +59,7 @@ client.users.me().then(function(user) {
 
 ## Installation
 
-Install with npm
+Install with npm:
 
 ```sh
 npm install asana --save
@@ -63,16 +67,16 @@ npm install asana --save
 
 ## Documentation
 
-The code is thoroughly documented with JsDoc tags and online documentation can
+The code is thoroughly documented with JsDoc tags, and online documentation can
 be found on the [wiki][wiki]. Also, the 
 [Official Asana Documentation][asana-doc] is a great resource since this is 
 just a thin wrapper for the API.
 
 ## Contributing
 
-Feel free to fork and submit pull requests for the code. Please follow the
+Feel free to fork and submit pull requests for the code! Please follow the
 existing code as an example of style and make sure that all your code passes
-lint and test. For a sanity check
+lint and tests. For a sanity check:
 
 ```sh
 git clone git@github.com:Asana/node-asana.git

--- a/examples/oauth/webserver/oauth_webserver.js
+++ b/examples/oauth/webserver/oauth_webserver.js
@@ -23,18 +23,22 @@ var clientId = process.env['ASANA_CLIENT_ID'];
 var clientSecret = process.env['ASANA_CLIENT_SECRET'];
 var port = process.env['PORT'] || 8338;
 
-// Create an Asana client.
-var client = Asana.Client.create({
-  clientId: clientId,
-  clientSecret: clientSecret,
-  redirectUri: 'http://localhost:' + port + '/oauth_callback'
-});
+// Create an Asana client. Do this per request since it keeps state that
+// shouldn't be shared across requests.
+function createClient() {
+  return Asana.Client.create({
+    clientId: clientId,
+    clientSecret: clientSecret,
+    redirectUri: 'http://localhost:' + port + '/oauth_callback'
+  });
+}
 
 // Causes request cookies to be parsed, populating `req.cookies`.
 app.use(cookieParser());
 
 // Home page - shows user name if authenticated, otherwise seeks authorization.
 app.get('/', function(req, res) {
+  var client = createClient();
   // If token is in the cookie, use it to show info.
   var token = req.cookies.token;
   if (token) {
@@ -60,6 +64,7 @@ app.get('/oauth_callback', function(req, res) {
   if (code) {
     // If we got a code back, then authorization succeeded.
     // Get token. Store it in the cookie and redirect home.
+    var client = createClient();
     client.app.accessTokenFromCode(code).then(function(credentials) {
       // The credentials contain the refresh token as well. If you use it, keep
       // it safe on the server! Here we just use the access token, and store it

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -12,11 +12,10 @@ var STATUS_MAP = Object.keys(errors).reduce(function(map, key) {
 
 // TODO: Provide same set of options for each request as for configuration,
 // so the config at construction time is just the "defaults"
-// TODO: remove `fullPayload` option, and let callers unwrap `data`
 
 /**
- * Creates a dispatcher which will augment the parameters passed to request with
- * the authKey: authValue mutation.
+ * Creates a dispatcher which will act as a basic wrapper for making HTTP
+ * requests to the API, and handle authentication.
  * @class
  * @classdesc A HTTP wrapper for the Asana API
  * @param {Object} options for default behavior of the Dispatcher
@@ -87,9 +86,7 @@ Dispatcher.prototype.authorize = function() {
  * Dispatches a request to the Asana API. The request parameters are passed to
  * the request module.
  * @param  {Object}  params The params for request
- * @param  {Object}  [dispatchOptions] Options for handling request/response:
- *     [boolean] fullPayload Return the full JSON payload instead of just the
- *         inner `data` field.
+ * @param  {Object}  [dispatchOptions] Options for handling request/response
  * @return {Promise}        The response for the request
  */
 Dispatcher.prototype.dispatch = function(params, dispatchOptions) {
@@ -117,7 +114,7 @@ Dispatcher.prototype.dispatch = function(params, dispatchOptions) {
             return reject(error);
           }
         } else {
-          return resolve(dispatchOptions.fullPayload ? payload : payload.data);
+          return resolve(payload);
         }
       });
     }

--- a/lib/resources/attachments.js
+++ b/lib/resources/attachments.js
@@ -22,7 +22,7 @@ util.inherits(Attachments, Resource);
  */
 Attachments.prototype.findById = function(attachmentId, params) {
   var path = util.format('/attachments/%d', attachmentId);
-  return this.get(path, params);
+  return this.dispatchGet(path, params);
 };
 
 /**
@@ -34,7 +34,7 @@ Attachments.prototype.findById = function(attachmentId, params) {
  */
 Attachments.prototype.findByTask = function(taskId, params) {
   var path = util.format('/tasks/%d/attachments', taskId);
-  return this.getCollection(path, params);
+  return this.dispatchGetCollection(path, params);
 };
 
 module.exports = Attachments;

--- a/lib/resources/attachments.js
+++ b/lib/resources/attachments.js
@@ -34,7 +34,7 @@ Attachments.prototype.findById = function(attachmentId, params) {
  */
 Attachments.prototype.findByTask = function(taskId, params) {
   var path = util.format('/tasks/%d/attachments', taskId);
-  return this.get(path, params);
+  return this.getCollection(path, params);
 };
 
 module.exports = Attachments;

--- a/lib/resources/attachments.js
+++ b/lib/resources/attachments.js
@@ -1,4 +1,5 @@
 var util = require('util');
+var Resource = require('./resource');
 
 /**
  * Constructs a resource accessor for Attachments that will use the dispatcher
@@ -8,12 +9,9 @@ var util = require('util');
  * @param {Dispatcher} dispatcher The API dispatcher
  */
 function Attachments(dispatcher) {
-  /**
-   * An instance of the dispatcher. This is usually passed from the client.
-   * @type {Dispatcher}
-   */
-  this.dispatcher = dispatcher;
+  Resource.call(this, dispatcher);
 }
+util.inherits(Attachments, Resource);
 
 /**
  * Dispatches a GET request to /attachments/:attachmentId of the API to get
@@ -24,7 +22,7 @@ function Attachments(dispatcher) {
  */
 Attachments.prototype.findById = function(attachmentId, params) {
   var path = util.format('/attachments/%d', attachmentId);
-  return this.dispatcher.get(path, params);
+  return this.get(path, params);
 };
 
 /**
@@ -36,7 +34,7 @@ Attachments.prototype.findById = function(attachmentId, params) {
  */
 Attachments.prototype.findByTask = function(taskId, params) {
   var path = util.format('/tasks/%d/attachments', taskId);
-  return this.dispatcher.get(path, params);
+  return this.get(path, params);
 };
 
 module.exports = Attachments;

--- a/lib/resources/events.js
+++ b/lib/resources/events.js
@@ -1,6 +1,4 @@
-var util = require('util');
 var EventStream = require('../util/event_stream');
-var Resource = require('./resource');
 
 /**
  * Constructs an accessor for Events that will use the dispatcher
@@ -10,9 +8,8 @@ var Resource = require('./resource');
  * @param {Dispatcher} dispatcher The API dispatcher
  */
 function Events(dispatcher) {
-  Resource.call(this, dispatcher);
+  this.dispatcher = dispatcher;
 }
-util.inherits(Events, Resource);
 
 /**
  * Dispatches a GET request to /events of the API to get a set of recent
@@ -36,7 +33,7 @@ Events.prototype.get = function(resourceId, syncToken) {
 
 
 /**
- * Begins polling the /events endpoint of the API to listent to changes
+ * Begins polling the /events endpoint of the API to listen to changes
  * to a resource.
  * @param  {Number} resourceId  The id of the resource to get events for
  * @param  {Object} [options]   Additional options to pass the stream.

--- a/lib/resources/events.js
+++ b/lib/resources/events.js
@@ -1,4 +1,6 @@
+var util = require('util');
 var EventStream = require('../util/event_stream');
+var Resource = require('./resource');
 
 /**
  * Constructs an accessor for Events that will use the dispatcher
@@ -8,12 +10,9 @@ var EventStream = require('../util/event_stream');
  * @param {Dispatcher} dispatcher The API dispatcher
  */
 function Events(dispatcher) {
-  /**
-   * An instance of the dispatcher. This is usually passed from the client.
-   * @type {Dispatcher}
-   */
-  this.dispatcher = dispatcher;
+  Resource.call(this, dispatcher);
 }
+util.inherits(Events, Resource);
 
 /**
  * Dispatches a GET request to /events of the API to get a set of recent
@@ -32,9 +31,7 @@ Events.prototype.get = function(resourceId, syncToken) {
   if (syncToken) {
     params.sync = syncToken;
   }
-  return this.dispatcher.get('/events', params, {
-    fullPayload: true
-  });
+  return this.dispatcher.get('/events', params);
 };
 
 

--- a/lib/resources/index.js
+++ b/lib/resources/index.js
@@ -1,3 +1,5 @@
+exports.Resource = require('./resource');
+
 exports.Attachments = require('./attachments');
 exports.Events = require('./events');
 exports.Projects = require('./projects');

--- a/lib/resources/projects.js
+++ b/lib/resources/projects.js
@@ -1,4 +1,5 @@
 var util = require('util');
+var Resource = require('./resource');
 
 /**
  * Constructs a resource accessor for Projects that will use the dispatcher
@@ -8,12 +9,9 @@ var util = require('util');
  * @param {Dispatcher} dispatcher The API dispatcher
  */
 function Projects(dispatcher) {
-  /**
-   * An instance of the dispatcher. This is usually passed from the client.
-   * @type {Dispatcher}
-   */
-  this.dispatcher = dispatcher;
+  Resource.call(this, dispatcher);
 }
+util.inherits(Projects, Resource);
 
 /**
  * Dispatches a POST request to /projects of the API to create a new project.
@@ -21,7 +19,7 @@ function Projects(dispatcher) {
  * @return {Promise}     The result of the API call
  */
 Projects.prototype.create = function(data) {
-  return this.dispatcher.post('/projects', data);
+  return this.post('/projects', data);
 };
 
 /**
@@ -33,7 +31,7 @@ Projects.prototype.create = function(data) {
  */
 Projects.prototype.createInWorkspace = function(workspaceId, data) {
   var path = util.format('/workspaces/%d/projects', workspaceId);
-  return this.dispatcher.post(path, data);
+  return this.post(path, data);
 };
 
 /**
@@ -45,7 +43,7 @@ Projects.prototype.createInWorkspace = function(workspaceId, data) {
  */
 Projects.prototype.findById = function(projectId, params) {
   var path = util.format('/projects/%d', projectId);
-  return this.dispatcher.get(path, params);
+  return this.get(path, params);
 };
 
 /**
@@ -55,7 +53,7 @@ Projects.prototype.findById = function(projectId, params) {
  * @return {Promise}         The result of the API call
  */
 Projects.prototype.findAll = function(params) {
-  return this.dispatcher.get('/projects', params);
+  return this.getCollection('/projects', params);
 };
 
 /**
@@ -67,7 +65,7 @@ Projects.prototype.findAll = function(params) {
  */
 Projects.prototype.findByWorkspace = function(workspaceId, params) {
   var path = util.format('/workspaces/%d/projects', workspaceId); 
-  return this.dispatcher.get(path, params);
+  return this.getCollection(path, params);
 };
 
 /**
@@ -78,17 +76,17 @@ Projects.prototype.findByWorkspace = function(workspaceId, params) {
  */
 Projects.prototype.update = function(projectId, data) {
   var path = util.format('/projects/%d', projectId);
-  return this.dispatcher.put(path, data);
+  return this.put(path, data);
 };
 
 /**
- * Dispatches a DELETE requte to /projects/:projectId to delete the project.
+ * Dispatches a DELETE request to /projects/:projectId to delete the project.
  * @param  {Number} projectId The project id
  * @return {Promise}          The result of the API call
  */
 Projects.prototype.delete = function(projectId) {
   var path = util.format('/projects/%d', projectId);
-  return this.dispatcher.delete(path);
+  return this.delete(path);
 };
 
 module.exports = Projects;

--- a/lib/resources/projects.js
+++ b/lib/resources/projects.js
@@ -19,7 +19,7 @@ util.inherits(Projects, Resource);
  * @return {Promise}     The result of the API call
  */
 Projects.prototype.create = function(data) {
-  return this.post('/projects', data);
+  return this.dispatchPost('/projects', data);
 };
 
 /**
@@ -31,7 +31,7 @@ Projects.prototype.create = function(data) {
  */
 Projects.prototype.createInWorkspace = function(workspaceId, data) {
   var path = util.format('/workspaces/%d/projects', workspaceId);
-  return this.post(path, data);
+  return this.dispatchPost(path, data);
 };
 
 /**
@@ -43,7 +43,7 @@ Projects.prototype.createInWorkspace = function(workspaceId, data) {
  */
 Projects.prototype.findById = function(projectId, params) {
   var path = util.format('/projects/%d', projectId);
-  return this.get(path, params);
+  return this.dispatchGet(path, params);
 };
 
 /**
@@ -53,7 +53,7 @@ Projects.prototype.findById = function(projectId, params) {
  * @return {Promise}         The result of the API call
  */
 Projects.prototype.findAll = function(params) {
-  return this.getCollection('/projects', params);
+  return this.dispatchGetCollection('/projects', params);
 };
 
 /**
@@ -65,7 +65,7 @@ Projects.prototype.findAll = function(params) {
  */
 Projects.prototype.findByWorkspace = function(workspaceId, params) {
   var path = util.format('/workspaces/%d/projects', workspaceId); 
-  return this.getCollection(path, params);
+  return this.dispatchGetCollection(path, params);
 };
 
 /**
@@ -76,7 +76,7 @@ Projects.prototype.findByWorkspace = function(workspaceId, params) {
  */
 Projects.prototype.update = function(projectId, data) {
   var path = util.format('/projects/%d', projectId);
-  return this.put(path, data);
+  return this.dispatchPut(path, data);
 };
 
 /**
@@ -84,9 +84,9 @@ Projects.prototype.update = function(projectId, data) {
  * @param  {Number} projectId The project id
  * @return {Promise}          The result of the API call
  */
-Projects.prototype.destroy = function(projectId) {
+Projects.prototype.delete = function(projectId) {
   var path = util.format('/projects/%d', projectId);
-  return this.delete(path);
+  return this.dispatchDelete(path);
 };
 
 module.exports = Projects;

--- a/lib/resources/projects.js
+++ b/lib/resources/projects.js
@@ -84,7 +84,7 @@ Projects.prototype.update = function(projectId, data) {
  * @param  {Number} projectId The project id
  * @return {Promise}          The result of the API call
  */
-Projects.prototype.delete = function(projectId) {
+Projects.prototype.destroy = function(projectId) {
   var path = util.format('/projects/%d', projectId);
   return this.delete(path);
 };

--- a/lib/resources/resource.js
+++ b/lib/resources/resource.js
@@ -1,0 +1,112 @@
+/**
+ * Base class for a resource accessible via the API. Uses a `Dispatcher` to
+ * access the resources.
+ * @param {Dispatcher} dispatcher
+ * @constructor
+ */
+function Resource(dispatcher) {
+  /**
+   * An instance of the dispatcher. This is usually passed from the client.
+   * @type {Dispatcher}
+   */
+  this.dispatcher = dispatcher;
+}
+
+/**
+ * @type {number} Default number of items to get per page.
+ */
+Resource.DEFAULT_PAGE_LIMIT = 50;
+
+/**
+ * Helper method that dispatches a GET request to the API, where the expected
+ * result is a collection.
+ * @param  {Dispatcher} dispatcher
+ * @param  {String}     path    The path of the API
+ * @param  {Object}     [query] The query params
+ * @param  {Object}     [dispatchOptions] Options for handling the request and
+ *     response. See `Dispatcher.dispatch`.
+ * @return {Promise}            The response for the request
+ */
+Resource.getCollection = function(dispatcher, path, query, dispatchOptions) {
+  query = query || {};
+  query.limit = query.limit || Resource.DEFAULT_PAGE_LIMIT;
+  return dispatcher.get(path, query, dispatchOptions);
+};
+
+/**
+ * Helper method for any request Promise from the Dispatcher, unwraps the `data`
+ * value from the payload.
+ * @param  {Promise} promise A promise returned from a `Dispatcher` request.
+ * @return {Promise}         The `data` portion of the response payload.
+ */
+Resource.unwrap = function(promise) {
+  return promise.then(function(payload) {
+    return payload.data;
+  });
+};
+
+/**
+ * Dispatches a GET request to the API, where the expected result is a
+ * single resource.
+ * @param  {String}     path    The path of the API
+ * @param  {Object}     [query] The query params
+ * @param  {Object}     [dispatchOptions] Options for handling the request and
+ *     response. See `Dispatcher.dispatch`.
+ * @return {Promise}            The response for the request
+ */
+Resource.prototype.get = function(path, query, dispatchOptions) {
+  return Resource.unwrap(this.dispatcher.get(path, query, dispatchOptions));
+};
+
+/**
+ * Dispatches a GET request to the API, where the expected result is a
+ * collection.
+ * @param  {String}     path    The path of the API
+ * @param  {Object}     [query] The query params
+ * @param  {Object}     [dispatchOptions] Options for handling the request and
+ *     response. See `Dispatcher.dispatch`.
+ * @return {Promise}            The response for the request
+ */
+Resource.prototype.getCollection = function(path, query, dispatchOptions) {
+  return Resource.getCollection(this.dispatcher, path, query, dispatchOptions);
+};
+
+/**
+ * Dispatches a POST request to the API, where the expected response is a
+ * single resource.
+ * @param  {String}     path    The path of the API
+ * @param  {Object}     [query] The query params
+ * @param  {Object}     [dispatchOptions] Options for handling the request and
+ *     response. See `Dispatcher.dispatch`.
+ * @return {Promise}            The response for the request
+ */
+Resource.prototype.post = function(path, query, dispatchOptions) {
+  return Resource.unwrap(this.dispatcher.post(path, query, dispatchOptions));
+};
+
+/**
+ * Dispatches a POST request to the API, where the expected response is a
+ * single resource.
+ * @param  {String}     path    The path of the API
+ * @param  {Object}     [query] The query params
+ * @param  {Object}     [dispatchOptions] Options for handling the request and
+ *     response. See `Dispatcher.dispatch`.
+ * @return {Promise}            The response for the request
+ */
+Resource.prototype.put = function(path, query, dispatchOptions) {
+  return Resource.unwrap(this.dispatcher.put(path, query, dispatchOptions));
+};
+
+/**
+ * Dispatches a DELETE request to the API. The expected response is an
+ * empty resource.
+ * @param  {String}     path    The path of the API
+ * @param  {Object}     [dispatchOptions] Options for handling the request and
+ *     response. See `Dispatcher.dispatch`.
+ * @return {Promise}            The response for the request
+ */
+Resource.prototype.delete = function(path, dispatchOptions) {
+  return Resource.unwrap(this.dispatcher.delete(path, dispatchOptions));
+};
+
+module.exports = Resource;

--- a/lib/resources/resource.js
+++ b/lib/resources/resource.js
@@ -54,7 +54,7 @@ Resource.unwrap = function(promise) {
  *     response. See `Dispatcher.dispatch`.
  * @return {Promise}            The response for the request
  */
-Resource.prototype.get = function(path, query, dispatchOptions) {
+Resource.prototype.dispatchGet = function(path, query, dispatchOptions) {
   return Resource.unwrap(this.dispatcher.get(path, query, dispatchOptions));
 };
 
@@ -67,7 +67,8 @@ Resource.prototype.get = function(path, query, dispatchOptions) {
  *     response. See `Dispatcher.dispatch`.
  * @return {Promise}            The response for the request
  */
-Resource.prototype.getCollection = function(path, query, dispatchOptions) {
+Resource.prototype.dispatchGetCollection =
+    function(path, query, dispatchOptions) {
   return Resource.getCollection(this.dispatcher, path, query, dispatchOptions);
 };
 
@@ -80,7 +81,7 @@ Resource.prototype.getCollection = function(path, query, dispatchOptions) {
  *     response. See `Dispatcher.dispatch`.
  * @return {Promise}            The response for the request
  */
-Resource.prototype.post = function(path, query, dispatchOptions) {
+Resource.prototype.dispatchPost = function(path, query, dispatchOptions) {
   return Resource.unwrap(this.dispatcher.post(path, query, dispatchOptions));
 };
 
@@ -93,7 +94,7 @@ Resource.prototype.post = function(path, query, dispatchOptions) {
  *     response. See `Dispatcher.dispatch`.
  * @return {Promise}            The response for the request
  */
-Resource.prototype.put = function(path, query, dispatchOptions) {
+Resource.prototype.dispatchPut = function(path, query, dispatchOptions) {
   return Resource.unwrap(this.dispatcher.put(path, query, dispatchOptions));
 };
 
@@ -105,7 +106,7 @@ Resource.prototype.put = function(path, query, dispatchOptions) {
  *     response. See `Dispatcher.dispatch`.
  * @return {Promise}            The response for the request
  */
-Resource.prototype.delete = function(path, dispatchOptions) {
+Resource.prototype.dispatchDelete = function(path, dispatchOptions) {
   return Resource.unwrap(this.dispatcher.delete(path, dispatchOptions));
 };
 

--- a/lib/resources/stories.js
+++ b/lib/resources/stories.js
@@ -1,4 +1,5 @@
 var util = require('util');
+var Resource = require('./resource');
 
 /**
  * Access to the Stories resource
@@ -6,8 +7,9 @@ var util = require('util');
  * @param {Dispatcher} dispatcher The API dispatcher
  */
 function Stories(dispatcher) {
-  this.dispatcher = dispatcher;
+  Resource.call(this, dispatcher);
 }
+util.inherits(Stories, Resource);
 
 /**
  * Returns the story
@@ -17,7 +19,7 @@ function Stories(dispatcher) {
  */
 Stories.prototype.findById = function(storyId, params) {
   var path = util.format('/stories/%d', storyId);
-  return this.dispatcher.get(path, params);
+  return this.get(path, params);
 };
 
 /**
@@ -28,7 +30,7 @@ Stories.prototype.findById = function(storyId, params) {
  */
 Stories.prototype.findByTask = function(taskId, params) {
   var path = util.format('/tasks/%d/stories', taskId);
-  return this.dispatcher.get(path, params);
+  return this.getCollection(path, params);
 };
 
 /**
@@ -39,7 +41,7 @@ Stories.prototype.findByTask = function(taskId, params) {
  */
 Stories.prototype.createOnTask = function(taskId, data) {
   var path = util.format('/tasks/%d/stories', taskId);
-  return this.dispatcher.post(path, data);
+  return this.post(path, data);
 };
 
 module.exports = Stories;

--- a/lib/resources/stories.js
+++ b/lib/resources/stories.js
@@ -19,7 +19,7 @@ util.inherits(Stories, Resource);
  */
 Stories.prototype.findById = function(storyId, params) {
   var path = util.format('/stories/%d', storyId);
-  return this.get(path, params);
+  return this.dispatchGet(path, params);
 };
 
 /**
@@ -30,7 +30,7 @@ Stories.prototype.findById = function(storyId, params) {
  */
 Stories.prototype.findByTask = function(taskId, params) {
   var path = util.format('/tasks/%d/stories', taskId);
-  return this.getCollection(path, params);
+  return this.dispatchGetCollection(path, params);
 };
 
 /**
@@ -41,7 +41,7 @@ Stories.prototype.findByTask = function(taskId, params) {
  */
 Stories.prototype.createOnTask = function(taskId, data) {
   var path = util.format('/tasks/%d/stories', taskId);
-  return this.post(path, data);
+  return this.dispatchPost(path, data);
 };
 
 module.exports = Stories;

--- a/lib/resources/tags.js
+++ b/lib/resources/tags.js
@@ -1,4 +1,5 @@
 var util = require('util');
+var Resource = require('./resource');
 
 /**
  * Access to the Tags resource
@@ -6,8 +7,9 @@ var util = require('util');
  * @param {Dispatcher} dispatcher The API dispatcher
  */
 function Tags(dispatcher) {
-  this.dispatcher = dispatcher;
+  Resource.call(this, dispatcher);
 }
+util.inherits(Tags, Resource);
 
 /**
  * Creates a new tag
@@ -15,7 +17,7 @@ function Tags(dispatcher) {
  * @return {Promise}     The result of the API call
  */
 Tags.prototype.create = function(data) {
-  return this.dispatcher.post('/tags', data);
+  return this.post('/tags', data);
 };
 
 /**
@@ -26,7 +28,7 @@ Tags.prototype.create = function(data) {
  */
 Tags.prototype.createInWorkspace = function(workspaceId, data) {
   var path = util.format('/workspaces/%d/tags', workspaceId);
-  return this.dispatcher.post(path, data);
+  return this.post(path, data);
 };
 
 /**
@@ -37,7 +39,7 @@ Tags.prototype.createInWorkspace = function(workspaceId, data) {
  */
 Tags.prototype.findById = function(tagId, params) {
   var path = util.format('/tags/%d', tagId);
-  return this.dispatcher.get(path, params);
+  return this.get(path, params);
 };
 
 /**
@@ -46,18 +48,18 @@ Tags.prototype.findById = function(tagId, params) {
  * @return {Promise}         The result of the API call
  */
 Tags.prototype.findAll = function(params) {
-  return this.dispatcher.get('/tags', params);
+  return this.getCollection('/tags', params);
 };
 
 /**
- * Finds a tag by workspace
+ * Finds all tags by workspace
  * @param  {Number} workspaceId The workspace id
  * @param  {Object} [params]    Extra params for the dispatcher
  * @return {Promise}            The result of the API call
  */
 Tags.prototype.findByWorkspace = function(workspaceId, params) {
   var path = util.format('/workspaces/%d/tags', workspaceId); 
-  return this.dispatcher.get(path, params);
+  return this.getCollection(path, params);
 };
 
 /**
@@ -68,7 +70,7 @@ Tags.prototype.findByWorkspace = function(workspaceId, params) {
  */
 Tags.prototype.update = function(tagId, data) {
   var path = util.format('/tags/%d', tagId);
-  return this.dispatcher.put(path, data);
+  return this.put(path, data);
 };
 
 module.exports = Tags;

--- a/lib/resources/tags.js
+++ b/lib/resources/tags.js
@@ -17,7 +17,7 @@ util.inherits(Tags, Resource);
  * @return {Promise}     The result of the API call
  */
 Tags.prototype.create = function(data) {
-  return this.post('/tags', data);
+  return this.dispatchPost('/tags', data);
 };
 
 /**
@@ -28,7 +28,7 @@ Tags.prototype.create = function(data) {
  */
 Tags.prototype.createInWorkspace = function(workspaceId, data) {
   var path = util.format('/workspaces/%d/tags', workspaceId);
-  return this.post(path, data);
+  return this.dispatchPost(path, data);
 };
 
 /**
@@ -39,7 +39,7 @@ Tags.prototype.createInWorkspace = function(workspaceId, data) {
  */
 Tags.prototype.findById = function(tagId, params) {
   var path = util.format('/tags/%d', tagId);
-  return this.get(path, params);
+  return this.dispatchGet(path, params);
 };
 
 /**
@@ -48,7 +48,7 @@ Tags.prototype.findById = function(tagId, params) {
  * @return {Promise}         The result of the API call
  */
 Tags.prototype.findAll = function(params) {
-  return this.getCollection('/tags', params);
+  return this.dispatchGetCollection('/tags', params);
 };
 
 /**
@@ -59,7 +59,7 @@ Tags.prototype.findAll = function(params) {
  */
 Tags.prototype.findByWorkspace = function(workspaceId, params) {
   var path = util.format('/workspaces/%d/tags', workspaceId); 
-  return this.getCollection(path, params);
+  return this.dispatchGetCollection(path, params);
 };
 
 /**
@@ -70,7 +70,7 @@ Tags.prototype.findByWorkspace = function(workspaceId, params) {
  */
 Tags.prototype.update = function(tagId, data) {
   var path = util.format('/tags/%d', tagId);
-  return this.put(path, data);
+  return this.dispatchPut(path, data);
 };
 
 module.exports = Tags;

--- a/lib/resources/tasks.js
+++ b/lib/resources/tasks.js
@@ -1,4 +1,5 @@
 var util = require('util');
+var Resource = require('./resource');
 
 /**
  * Access to the Tasks resource
@@ -6,8 +7,9 @@ var util = require('util');
  * @param {Dispatcher} dispatcher The API dispatcher
  */
 function Tasks(dispatcher) {
-  this.dispatcher = dispatcher;
+  Resource.call(this, dispatcher);
 }
+util.inherits(Tasks, Resource);
 
 /**
  * Creates a new task
@@ -15,7 +17,7 @@ function Tasks(dispatcher) {
  * @return {Promise}     The result of the API call
  */
 Tasks.prototype.create = function(data) {
-  return this.dispatcher.post('/tasks', data);
+  return this.post('/tasks', data);
 };
 
 /**
@@ -26,22 +28,22 @@ Tasks.prototype.create = function(data) {
  */
 Tasks.prototype.createInWorkspace = function(workspaceId, data) {
   var path = util.format('/workspaces/%d/tasks', workspaceId);
-  return this.dispatcher.post(path, data);
+  return this.post(path, data);
 };
 
 /**
- * Returns the task
+ * Returns the task named by the given Asana ID
  * @param  {Number} taskId   The task id
  * @param  {Object} [params] Extra params for the dispatcher
  * @return {Promise}         The result of the API call
  */
 Tasks.prototype.findById = function(taskId, params) {
   var path = util.format('/tasks/%d', taskId);
-  return this.dispatcher.get(path, params);
+  return this.get(path, params);
 };
 
 /**
- * Returns the task
+ * Returns the task named by the given external ID
  * @param  {String}  externalId   The task id
  * @param  {String}  workspaceId  The workspace containing the task
  * @param  {Object} [params] Extra params for the dispatcher
@@ -50,8 +52,8 @@ Tasks.prototype.findById = function(taskId, params) {
 Tasks.prototype.findByExternalId = function(externalId, workspaceId, params) {
   params = params || {};
   params.workspace = workspaceId;
-  var path = util.format('/tasks/external:' + externalId);
-  return this.dispatcher.get(path, params);
+  var path = '/tasks/external:' + externalId;
+  return this.get(path, params);
 };
 
 /**
@@ -60,7 +62,7 @@ Tasks.prototype.findByExternalId = function(externalId, workspaceId, params) {
  * @return {Promise}         The result of the API call
  */
 Tasks.prototype.findAll = function(params) {
-  return this.dispatcher.get('/tasks', params);
+  return this.getCollection('/tasks', params);
 };
 
 /**
@@ -71,7 +73,7 @@ Tasks.prototype.findAll = function(params) {
  */
 Tasks.prototype.findByProject = function(projectId, params) {
   var path = util.format('/projects/%d/tasks', projectId);
-  return this.dispatcher.get(path, params);
+  return this.getCollection(path, params);
 };
 
 /**
@@ -82,7 +84,7 @@ Tasks.prototype.findByProject = function(projectId, params) {
  */
 Tasks.prototype.findByTag = function(tagId, params) {
   var path = util.format('/tags/%d/tasks', tagId);
-  return this.dispatcher.get(path, params);
+  return this.getCollection(path, params);
 };
 
 /**
@@ -100,7 +102,7 @@ Tasks.prototype.findByTag = function(tagId, params) {
  */
 Tasks.prototype.update = function(taskId, data) {
   var path = util.format('/tasks/%d', taskId);
-  return this.dispatcher.put(path, data);
+  return this.put(path, data);
 };
 
 /**
@@ -110,7 +112,7 @@ Tasks.prototype.update = function(taskId, data) {
  */
 Tasks.prototype.delete = function(taskId) {
   var path = util.format('/tasks/%d', taskId);
-  return this.dispatcher.delete(path);
+  return this.delete(path);
 };
 
 /**
@@ -121,7 +123,7 @@ Tasks.prototype.delete = function(taskId) {
  */
 Tasks.prototype.addFollowers = function(taskId, data) {
   var path = util.format('/tasks/%d/addFollowers', taskId);
-  return this.dispatcher.post(path, data);
+  return this.post(path, data);
 };
 
 /**
@@ -132,7 +134,7 @@ Tasks.prototype.addFollowers = function(taskId, data) {
  */
 Tasks.prototype.removeFollowers = function(taskId, data) {
   var path = util.format('/tasks/%d/removeFollowers', taskId);
-  return this.dispatcher.post(path, data);
+  return this.post(path, data);
 };
 
 /**
@@ -142,7 +144,7 @@ Tasks.prototype.removeFollowers = function(taskId, data) {
  */
 Tasks.prototype.projects = function(taskId) {
   var path = util.format('/tasks/%d/projects', taskId);
-  return this.dispatcher.get(path, undefined);
+  return this.getCollection(path, undefined);
 };
 
 /**
@@ -154,7 +156,7 @@ Tasks.prototype.projects = function(taskId) {
  */
 Tasks.prototype.addProject = function(taskId, data) {
   var path = util.format('/tasks/%d/addProject', taskId);
-  return this.dispatcher.post(path, data);
+  return this.post(path, data);
 };
 
 /**
@@ -166,7 +168,7 @@ Tasks.prototype.addProject = function(taskId, data) {
  */
 Tasks.prototype.removeProject = function(taskId, data) {
   var path = util.format('/tasks/%d/removeProject', taskId);
-  return this.dispatcher.post(path, data);
+  return this.post(path, data);
 };
 
 /**
@@ -176,7 +178,7 @@ Tasks.prototype.removeProject = function(taskId, data) {
  */
 Tasks.prototype.tags = function(taskId) {
   var path = util.format('/tasks/%d/tags', taskId);
-  return this.dispatcher.get(path, undefined);
+  return this.getCollection(path, undefined);
 };
 
 /**
@@ -187,7 +189,7 @@ Tasks.prototype.tags = function(taskId) {
  */
 Tasks.prototype.addTag = function(taskId, data) {
   var path = util.format('/tasks/%d/addTag', taskId);
-  return this.dispatcher.post(path, data);
+  return this.post(path, data);
 };
 
 /**
@@ -199,7 +201,7 @@ Tasks.prototype.addTag = function(taskId, data) {
  */
 Tasks.prototype.removeTag = function(taskId, data) {
   var path = util.format('/tasks/%d/removeTag', taskId);
-  return this.dispatcher.post(path, data);
+  return this.post(path, data);
 };
 
 /**
@@ -209,7 +211,7 @@ Tasks.prototype.removeTag = function(taskId, data) {
  */
 Tasks.prototype.subtasks = function(taskId) {
   var path = util.format('/tasks/%d/subtasks', taskId);
-  return this.dispatcher.get(path, undefined);
+  return this.getCollection(path, undefined);
 };
 
 /**
@@ -220,7 +222,7 @@ Tasks.prototype.subtasks = function(taskId) {
  */
 Tasks.prototype.addSubtask = function(taskId, data) {
   var path = util.format('/tasks/%d/subtasks', taskId);
-  return this.dispatcher.post(path, data);
+  return this.post(path, data);
 };
 
 /**
@@ -231,7 +233,7 @@ Tasks.prototype.addSubtask = function(taskId, data) {
  */
 Tasks.prototype.setParent = function(taskId, parentId) {
   var path = util.format('/tasks/%d/setParent', taskId);
-  return this.dispatcher.post(path, {
+  return this.post(path, {
     parent: Number(parentId)
   });
 };

--- a/lib/resources/tasks.js
+++ b/lib/resources/tasks.js
@@ -17,7 +17,7 @@ util.inherits(Tasks, Resource);
  * @return {Promise}     The result of the API call
  */
 Tasks.prototype.create = function(data) {
-  return this.post('/tasks', data);
+  return this.dispatchPost('/tasks', data);
 };
 
 /**
@@ -28,7 +28,7 @@ Tasks.prototype.create = function(data) {
  */
 Tasks.prototype.createInWorkspace = function(workspaceId, data) {
   var path = util.format('/workspaces/%d/tasks', workspaceId);
-  return this.post(path, data);
+  return this.dispatchPost(path, data);
 };
 
 /**
@@ -39,7 +39,7 @@ Tasks.prototype.createInWorkspace = function(workspaceId, data) {
  */
 Tasks.prototype.findById = function(taskId, params) {
   var path = util.format('/tasks/%d', taskId);
-  return this.get(path, params);
+  return this.dispatchGet(path, params);
 };
 
 /**
@@ -53,7 +53,7 @@ Tasks.prototype.findByExternalId = function(externalId, workspaceId, params) {
   params = params || {};
   params.workspace = workspaceId;
   var path = '/tasks/external:' + externalId;
-  return this.get(path, params);
+  return this.dispatchGet(path, params);
 };
 
 /**
@@ -62,7 +62,7 @@ Tasks.prototype.findByExternalId = function(externalId, workspaceId, params) {
  * @return {Promise}         The result of the API call
  */
 Tasks.prototype.findAll = function(params) {
-  return this.getCollection('/tasks', params);
+  return this.dispatchGetCollection('/tasks', params);
 };
 
 /**
@@ -73,7 +73,7 @@ Tasks.prototype.findAll = function(params) {
  */
 Tasks.prototype.findByProject = function(projectId, params) {
   var path = util.format('/projects/%d/tasks', projectId);
-  return this.getCollection(path, params);
+  return this.dispatchGetCollection(path, params);
 };
 
 /**
@@ -84,7 +84,7 @@ Tasks.prototype.findByProject = function(projectId, params) {
  */
 Tasks.prototype.findByTag = function(tagId, params) {
   var path = util.format('/tags/%d/tasks', tagId);
-  return this.getCollection(path, params);
+  return this.dispatchGetCollection(path, params);
 };
 
 /**
@@ -102,7 +102,7 @@ Tasks.prototype.findByTag = function(tagId, params) {
  */
 Tasks.prototype.update = function(taskId, data) {
   var path = util.format('/tasks/%d', taskId);
-  return this.put(path, data);
+  return this.dispatchPut(path, data);
 };
 
 /**
@@ -110,9 +110,9 @@ Tasks.prototype.update = function(taskId, data) {
  * @param  {Number} taskId The task id
  * @return {Promise}       The result of the API call
  */
-Tasks.prototype.destroy = function(taskId) {
+Tasks.prototype.delete = function(taskId) {
   var path = util.format('/tasks/%d', taskId);
-  return this.delete(path);
+  return this.dispatchDelete(path);
 };
 
 /**
@@ -123,7 +123,7 @@ Tasks.prototype.destroy = function(taskId) {
  */
 Tasks.prototype.addFollowers = function(taskId, data) {
   var path = util.format('/tasks/%d/addFollowers', taskId);
-  return this.post(path, data);
+  return this.dispatchPost(path, data);
 };
 
 /**
@@ -134,7 +134,7 @@ Tasks.prototype.addFollowers = function(taskId, data) {
  */
 Tasks.prototype.removeFollowers = function(taskId, data) {
   var path = util.format('/tasks/%d/removeFollowers', taskId);
-  return this.post(path, data);
+  return this.dispatchPost(path, data);
 };
 
 /**
@@ -144,7 +144,7 @@ Tasks.prototype.removeFollowers = function(taskId, data) {
  */
 Tasks.prototype.projects = function(taskId) {
   var path = util.format('/tasks/%d/projects', taskId);
-  return this.getCollection(path, undefined);
+  return this.dispatchGetCollection(path, undefined);
 };
 
 /**
@@ -156,7 +156,7 @@ Tasks.prototype.projects = function(taskId) {
  */
 Tasks.prototype.addProject = function(taskId, data) {
   var path = util.format('/tasks/%d/addProject', taskId);
-  return this.post(path, data);
+  return this.dispatchPost(path, data);
 };
 
 /**
@@ -168,7 +168,7 @@ Tasks.prototype.addProject = function(taskId, data) {
  */
 Tasks.prototype.removeProject = function(taskId, data) {
   var path = util.format('/tasks/%d/removeProject', taskId);
-  return this.post(path, data);
+  return this.dispatchPost(path, data);
 };
 
 /**
@@ -178,7 +178,7 @@ Tasks.prototype.removeProject = function(taskId, data) {
  */
 Tasks.prototype.tags = function(taskId) {
   var path = util.format('/tasks/%d/tags', taskId);
-  return this.getCollection(path, undefined);
+  return this.dispatchGetCollection(path, undefined);
 };
 
 /**
@@ -189,7 +189,7 @@ Tasks.prototype.tags = function(taskId) {
  */
 Tasks.prototype.addTag = function(taskId, data) {
   var path = util.format('/tasks/%d/addTag', taskId);
-  return this.post(path, data);
+  return this.dispatchPost(path, data);
 };
 
 /**
@@ -201,7 +201,7 @@ Tasks.prototype.addTag = function(taskId, data) {
  */
 Tasks.prototype.removeTag = function(taskId, data) {
   var path = util.format('/tasks/%d/removeTag', taskId);
-  return this.post(path, data);
+  return this.dispatchPost(path, data);
 };
 
 /**
@@ -211,7 +211,7 @@ Tasks.prototype.removeTag = function(taskId, data) {
  */
 Tasks.prototype.subtasks = function(taskId) {
   var path = util.format('/tasks/%d/subtasks', taskId);
-  return this.getCollection(path, undefined);
+  return this.dispatchGetCollection(path, undefined);
 };
 
 /**
@@ -222,7 +222,7 @@ Tasks.prototype.subtasks = function(taskId) {
  */
 Tasks.prototype.addSubtask = function(taskId, data) {
   var path = util.format('/tasks/%d/subtasks', taskId);
-  return this.post(path, data);
+  return this.dispatchPost(path, data);
 };
 
 /**
@@ -233,7 +233,7 @@ Tasks.prototype.addSubtask = function(taskId, data) {
  */
 Tasks.prototype.setParent = function(taskId, parentId) {
   var path = util.format('/tasks/%d/setParent', taskId);
-  return this.post(path, {
+  return this.dispatchPost(path, {
     parent: Number(parentId)
   });
 };

--- a/lib/resources/tasks.js
+++ b/lib/resources/tasks.js
@@ -110,7 +110,7 @@ Tasks.prototype.update = function(taskId, data) {
  * @param  {Number} taskId The task id
  * @return {Promise}       The result of the API call
  */
-Tasks.prototype.delete = function(taskId) {
+Tasks.prototype.destroy = function(taskId) {
   var path = util.format('/tasks/%d', taskId);
   return this.delete(path);
 };

--- a/lib/resources/teams.js
+++ b/lib/resources/teams.js
@@ -19,7 +19,7 @@ util.inherits(Teams, Resource);
  */
 Teams.prototype.findByOrganization = function(organizationId, params) {
   var path = util.format('/organizations/%d/teams', organizationId);
-  return this.getCollection(path, params);
+  return this.dispatchGetCollection(path, params);
 };
 
 module.exports = Teams;

--- a/lib/resources/teams.js
+++ b/lib/resources/teams.js
@@ -1,4 +1,5 @@
 var util = require('util');
+var Resource = require('./resource');
 
 /**
  * Access to the Teams resource
@@ -6,8 +7,9 @@ var util = require('util');
  * @param {Dispatcher} dispatcher The API dispatcher
  */
 function Teams(dispatcher) {
-  this.dispatcher = dispatcher;
+  Resource.call(this, dispatcher);
 }
+util.inherits(Teams, Resource);
 
 /**
  * Finds all teams that the user has access to
@@ -17,7 +19,7 @@ function Teams(dispatcher) {
  */
 Teams.prototype.findByOrganization = function(organizationId, params) {
   var path = util.format('/organizations/%d/teams', organizationId);
-  return this.dispatcher.get(path, params);
+  return this.getCollection(path, params);
 };
 
 module.exports = Teams;

--- a/lib/resources/users.js
+++ b/lib/resources/users.js
@@ -1,4 +1,5 @@
 var util = require('util');
+var Resource = require('./resource');
 
 /**
  * Access to the Users resource
@@ -6,8 +7,9 @@ var util = require('util');
  * @param {Dispatcher} dispatcher The API dispatcher
  */
 function Users(dispatcher) {
-  this.dispatcher = dispatcher;
+  Resource.call(this, dispatcher);
 }
+util.inherits(Users, Resource);
 
 /**
  * Returns all users that the dispatcher has access to
@@ -15,7 +17,7 @@ function Users(dispatcher) {
  * @return {Promise}         The result of the API call
  */
 Users.prototype.findAll = function(params) {
-  return this.dispatcher.get('/users', params);
+  return this.getCollection('/users', params);
 };
 
 /**
@@ -24,7 +26,7 @@ Users.prototype.findAll = function(params) {
  * @return {Promise}         The result of the API call
  */
 Users.prototype.me = function(params) {
-  return this.dispatcher.get('/users/me', params);
+  return this.get('/users/me', params);
 };
 
 /**
@@ -35,18 +37,18 @@ Users.prototype.me = function(params) {
  */
 Users.prototype.findById = function(userId, params) {
   var path = util.format('/users/%d', userId);
-  return this.dispatcher.get(path, params);
+  return this.get(path, params);
 };
 
 /**
- * Finds a user by workspace
+ * Finds all users by workspace
  * @param  {Number} workspaceId The workspace id
  * @param  {Object} [params]    Extra params for the dispatcher
  * @return {Promise}            The result of the API call
  */
 Users.prototype.findByWorkspace = function(workspaceId, params) {
   var path = util.format('/workspaces/%d/users', workspaceId); 
-  return this.dispatcher.get(path, params);
+  return this.getCollection(path, params);
 };
 
 module.exports = Users;

--- a/lib/resources/users.js
+++ b/lib/resources/users.js
@@ -17,7 +17,7 @@ util.inherits(Users, Resource);
  * @return {Promise}         The result of the API call
  */
 Users.prototype.findAll = function(params) {
-  return this.getCollection('/users', params);
+  return this.dispatchGetCollection('/users', params);
 };
 
 /**
@@ -26,7 +26,7 @@ Users.prototype.findAll = function(params) {
  * @return {Promise}         The result of the API call
  */
 Users.prototype.me = function(params) {
-  return this.get('/users/me', params);
+  return this.dispatchGet('/users/me', params);
 };
 
 /**
@@ -37,7 +37,7 @@ Users.prototype.me = function(params) {
  */
 Users.prototype.findById = function(userId, params) {
   var path = util.format('/users/%d', userId);
-  return this.get(path, params);
+  return this.dispatchGet(path, params);
 };
 
 /**
@@ -48,7 +48,7 @@ Users.prototype.findById = function(userId, params) {
  */
 Users.prototype.findByWorkspace = function(workspaceId, params) {
   var path = util.format('/workspaces/%d/users', workspaceId); 
-  return this.getCollection(path, params);
+  return this.dispatchGetCollection(path, params);
 };
 
 module.exports = Users;

--- a/lib/resources/workspaces.js
+++ b/lib/resources/workspaces.js
@@ -17,7 +17,7 @@ util.inherits(Workspaces, Resource);
  * @return {Promise}         The result of the API call
  */
 Workspaces.prototype.findAll = function(params) {
-  return this.getCollection('/workspaces', params);
+  return this.dispatchGetCollection('/workspaces', params);
 };
 
 /**
@@ -28,7 +28,7 @@ Workspaces.prototype.findAll = function(params) {
  */
 Workspaces.prototype.update = function(workspaceId, data) {
   var path = util.format('/workspaces/%d', workspaceId);
-  return this.put(path, data);
+  return this.dispatchPut(path, data);
 };
 
 /**
@@ -39,7 +39,7 @@ Workspaces.prototype.update = function(workspaceId, data) {
  */
 Workspaces.prototype.typeahead = function(workspaceId, data) {
   var path = util.format('/workspaces/%d/typeahead', workspaceId);
-  return this.getCollection(path, data);
+  return this.dispatchGetCollection(path, data);
 };
 
 module.exports = Workspaces;

--- a/lib/resources/workspaces.js
+++ b/lib/resources/workspaces.js
@@ -1,4 +1,5 @@
 var util = require('util');
+var Resource = require('./resource');
 
 /**
  * Access to the Workspaces resource
@@ -6,8 +7,9 @@ var util = require('util');
  * @param {Dispatcher} dispatcher The API dispatcher
  */
 function Workspaces(dispatcher) {
-  this.dispatcher = dispatcher;
+  Resource.call(this, dispatcher);
 }
+util.inherits(Workspaces, Resource);
 
 /**
  * Show all available workspaces
@@ -15,7 +17,7 @@ function Workspaces(dispatcher) {
  * @return {Promise}         The result of the API call
  */
 Workspaces.prototype.findAll = function(params) {
-  return this.dispatcher.get('/workspaces', params);
+  return this.getCollection('/workspaces', params);
 };
 
 /**
@@ -26,7 +28,7 @@ Workspaces.prototype.findAll = function(params) {
  */
 Workspaces.prototype.update = function(workspaceId, data) {
   var path = util.format('/workspaces/%d', workspaceId);
-  return this.dispatcher.put(path, data);
+  return this.put(path, data);
 };
 
 /**
@@ -37,7 +39,7 @@ Workspaces.prototype.update = function(workspaceId, data) {
  */
 Workspaces.prototype.typeahead = function(workspaceId, data) {
   var path = util.format('/workspaces/%d/typeahead', workspaceId);
-  return this.dispatcher.get(path, data);
+  return this.getCollection(path, data);
 };
 
 module.exports = Workspaces;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asana",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "A node.js client for the Asana API",
   "main": "index.js",
   "scripts": {

--- a/test/client_spec.js
+++ b/test/client_spec.js
@@ -86,6 +86,9 @@ describe('Client', function() {
 
   describe('#resources', function() {
     Object.keys(resources).forEach(function(key) {
+      if (key === 'Resource') {
+        return;
+      }
       it('should have ' + key, function() {
         var dispatcher = new Dispatcher({});
         var client = new Client(dispatcher);

--- a/test/dispatcher_spec.js
+++ b/test/dispatcher_spec.js
@@ -106,13 +106,11 @@ describe('Dispatcher', function() {
     });
 
     it('should retry on rate limit error if option set', function() {
-      var fakeData = {};
-
       var request = sinon.stub();
       request.onFirstCall().callsArgWith(
           1, null, { statusCode: 429 }, { 'retry_after': 42 });
       request.onSecondCall().callsArgWith(
-          1, null, { statusCode: 200 }, { data: fakeData });
+          1, null, { statusCode: 200 }, {});
       Dispatcher.__set__('request', request);
 
       var setTimeout = sinon.stub();
@@ -127,17 +125,18 @@ describe('Dispatcher', function() {
 
       var res = dispatcher.dispatch({});
 
-      return res.then(function(data) {
-        assert.equal(data, fakeData);
+      return res.then(function() {
         assert.equal(setTimeout.firstCall.args[1], 42500);
       });
     });
 
-    it('should pass the data as the value', function() {
+    it('should pass the whole payload as the value', function() {
       var request = sinon.stub();
       var payload = {
-        id: 1,
-        name: 'Task'
+        data: {
+          id: 1,
+          name: 'Task'
+        }
       };
       Dispatcher.__set__('request', request);
       var auth = { authenticateRequest: sinon.stub() };
@@ -145,9 +144,7 @@ describe('Dispatcher', function() {
       var res = dispatcher.dispatch({});
       request.callArgWith(1, null, {
         statusCode: 200
-      }, {
-        data: payload
-      });
+      }, payload);
       return res.then(function(value) {
         assert.equal(value, payload);
       });

--- a/test/resources/attachments_spec.js
+++ b/test/resources/attachments_spec.js
@@ -14,60 +14,50 @@ describe('Attachments', function() {
 
   describe('#findById', function() {
     it('should handle without params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var attachments = new Attachments(dispatcher);
       var id = 1;
       attachments.findById(id);
-      assert(dispatcher.get.calledWithExactly('/attachments/1', undefined));
+      assert(this.get.calledWithExactly('/attachments/1', undefined));
     });
 
     it('should handle with params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var attachments = new Attachments(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       attachments.findById(id, params);
-      assert(dispatcher.get.calledWithExactly('/attachments/1', params));
+      assert(this.get.calledWithExactly('/attachments/1', params));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var attachments = new Attachments(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       attachments.findById(id, params);
-      assert(dispatcher.get.calledWithExactly('/attachments/1', params));
+      assert(this.get.calledWithExactly('/attachments/1', params));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var attachments = new Attachments(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       attachments.findById(id, params);
-      assert(dispatcher.get.calledWithExactly('/attachments/NaN', params));
+      assert(this.get.calledWithExactly('/attachments/NaN', params));
     });
   });
 
   describe('#findByTask', function() {
     it('should handle without params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var attachments = new Attachments(dispatcher);
       var id = 1;
       attachments.findByTask(id);
@@ -76,35 +66,29 @@ describe('Attachments', function() {
     });
 
     it('should handle with params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var attachments = new Attachments(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       attachments.findByTask(id, params);
-      assert(dispatcher.get.calledWithExactly('/tasks/1/attachments', params));
+      assert(this.get.calledWithExactly('/tasks/1/attachments', params));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var attachments = new Attachments(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       attachments.findByTask(id, params);
-      assert(dispatcher.get.calledWithExactly('/tasks/1/attachments', params));
+      assert(this.get.calledWithExactly('/tasks/1/attachments', params));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var attachments = new Attachments(dispatcher);
       var params = {
         'opt_fields': 'id,name'

--- a/test/resources/attachments_spec.js
+++ b/test/resources/attachments_spec.js
@@ -16,46 +16,52 @@ describe('Attachments', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var attachments = new Attachments(dispatcher);
-      attachments.get = sinon.stub();
+      attachments.dispatchGet = sinon.stub();
       var id = 1;
       attachments.findById(id);
-      assert(attachments.get.calledWithExactly('/attachments/1', undefined));
+      assert(
+          attachments.dispatchGet.calledWithExactly(
+              '/attachments/1', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var attachments = new Attachments(dispatcher);
-      attachments.get = sinon.stub();
+      attachments.dispatchGet = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       attachments.findById(id, params);
-      assert(attachments.get.calledWithExactly('/attachments/1', params));
+      assert(
+          attachments.dispatchGet.calledWithExactly('/attachments/1', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var attachments = new Attachments(dispatcher);
-      attachments.get = sinon.stub();
+      attachments.dispatchGet = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       attachments.findById(id, params);
-      assert(attachments.get.calledWithExactly('/attachments/1', params));
+      assert(
+          attachments.dispatchGet.calledWithExactly('/attachments/1', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var attachments = new Attachments(dispatcher);
-      attachments.get = sinon.stub();
+      attachments.dispatchGet = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       attachments.findById(id, params);
-      assert(attachments.get.calledWithExactly('/attachments/NaN', params));
+      assert(
+          attachments.dispatchGet.calledWithExactly(
+              '/attachments/NaN', params));
     });
   });
 
@@ -63,53 +69,53 @@ describe('Attachments', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var attachments = new Attachments(dispatcher);
-      attachments.getCollection = sinon.stub();
+      attachments.dispatchGetCollection = sinon.stub();
       var id = 1;
       attachments.findByTask(id);
       assert(
-          attachments.getCollection.calledWithExactly(
+          attachments.dispatchGetCollection.calledWithExactly(
               '/tasks/1/attachments', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var attachments = new Attachments(dispatcher);
-      attachments.getCollection = sinon.stub();
+      attachments.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       attachments.findByTask(id, params);
       assert(
-          attachments.getCollection.calledWithExactly(
+          attachments.dispatchGetCollection.calledWithExactly(
               '/tasks/1/attachments', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var attachments = new Attachments(dispatcher);
-      attachments.getCollection = sinon.stub();
+      attachments.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       attachments.findByTask(id, params);
       assert(
-          attachments.getCollection.calledWithExactly(
+          attachments.dispatchGetCollection.calledWithExactly(
               '/tasks/1/attachments', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var attachments = new Attachments(dispatcher);
-      attachments.getCollection = sinon.stub();
+      attachments.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       attachments.findByTask(id, params);
       assert(
-        attachments.getCollection.calledWithExactly(
+        attachments.dispatchGetCollection.calledWithExactly(
             '/tasks/NaN/attachments', params));
     });
   });

--- a/test/resources/attachments_spec.js
+++ b/test/resources/attachments_spec.js
@@ -16,42 +16,46 @@ describe('Attachments', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var attachments = new Attachments(dispatcher);
+      attachments.get = sinon.stub();
       var id = 1;
       attachments.findById(id);
-      assert(this.get.calledWithExactly('/attachments/1', undefined));
+      assert(attachments.get.calledWithExactly('/attachments/1', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var attachments = new Attachments(dispatcher);
+      attachments.get = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       attachments.findById(id, params);
-      assert(this.get.calledWithExactly('/attachments/1', params));
+      assert(attachments.get.calledWithExactly('/attachments/1', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var attachments = new Attachments(dispatcher);
+      attachments.get = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       attachments.findById(id, params);
-      assert(this.get.calledWithExactly('/attachments/1', params));
+      assert(attachments.get.calledWithExactly('/attachments/1', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var attachments = new Attachments(dispatcher);
+      attachments.get = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       attachments.findById(id, params);
-      assert(this.get.calledWithExactly('/attachments/NaN', params));
+      assert(attachments.get.calledWithExactly('/attachments/NaN', params));
     });
   });
 
@@ -59,44 +63,54 @@ describe('Attachments', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var attachments = new Attachments(dispatcher);
+      attachments.getCollection = sinon.stub();
       var id = 1;
       attachments.findByTask(id);
       assert(
-        dispatcher.get.calledWithExactly('/tasks/1/attachments', undefined));
+          attachments.getCollection.calledWithExactly(
+              '/tasks/1/attachments', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var attachments = new Attachments(dispatcher);
+      attachments.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       attachments.findByTask(id, params);
-      assert(this.get.calledWithExactly('/tasks/1/attachments', params));
+      assert(
+          attachments.getCollection.calledWithExactly(
+              '/tasks/1/attachments', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var attachments = new Attachments(dispatcher);
+      attachments.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       attachments.findByTask(id, params);
-      assert(this.get.calledWithExactly('/tasks/1/attachments', params));
+      assert(
+          attachments.getCollection.calledWithExactly(
+              '/tasks/1/attachments', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var attachments = new Attachments(dispatcher);
+      attachments.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       attachments.findByTask(id, params);
       assert(
-        dispatcher.get.calledWithExactly('/tasks/NaN/attachments', params));
+        attachments.getCollection.calledWithExactly(
+            '/tasks/NaN/attachments', params));
     });
   });
 });

--- a/test/resources/events_spec.js
+++ b/test/resources/events_spec.js
@@ -26,8 +26,6 @@ describe('Events', function() {
         dispatcher.get.calledWithExactly(
           '/events', {
             resource: 1
-          }, {
-            fullPayload: true
           }));
     });
 
@@ -44,8 +42,6 @@ describe('Events', function() {
           '/events', {
             resource: 1,
             sync: token
-          }, {
-            fullPayload: true
           }));
     });
   });

--- a/test/resources/projects_spec.js
+++ b/test/resources/projects_spec.js
@@ -16,11 +16,12 @@ describe('Projects', function() {
     it('should handle the creation', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
+      projects.post = sinon.stub();
       var data = {
         name: 'Test'
       };
       projects.create(data);
-      assert(this.post.calledWithExactly('/projects', data));
+      assert(projects.post.calledWithExactly('/projects', data));
     });
   });
 
@@ -28,35 +29,38 @@ describe('Projects', function() {
     it('should handle the creation', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
+      projects.post = sinon.stub();
       var id = 1;
       var data = {
         name: 'Test'
       };
       projects.createInWorkspace(id, data);
-      assert(this.post.calledWithExactly('/workspaces/1/projects', data));
+      assert(projects.post.calledWithExactly('/workspaces/1/projects', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
+      projects.post = sinon.stub();
       var id = '1';
       var data = {
         name: 'Test'
       };
       projects.createInWorkspace(id, data);
-      assert(this.post.calledWithExactly('/workspaces/1/projects', data));
+      assert(projects.post.calledWithExactly('/workspaces/1/projects', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
+      projects.post = sinon.stub();
       var id = 'foobar';
       var data = {
         name: 'Test'
       };
       projects.createInWorkspace(id, data);
       assert(
-        dispatcher.post.calledWithExactly('/workspaces/NaN/projects', data));
+          projects.post.calledWithExactly('/workspaces/NaN/projects', data));
     });
   });
 
@@ -64,18 +68,20 @@ describe('Projects', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
+      projects.getCollection = sinon.stub();
       projects.findAll();
-      assert(this.get.calledWithExactly('/projects', undefined));
+      assert(projects.getCollection.calledWithExactly('/projects', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
+      projects.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       projects.findAll(params);
-      assert(this.get.calledWithExactly('/projects', params));
+      assert(projects.getCollection.calledWithExactly('/projects', params));
     });
   });
 
@@ -83,42 +89,46 @@ describe('Projects', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
+      projects.get = sinon.stub();
       var id = 1;
       projects.findById(id);
-      assert(this.get.calledWithExactly('/projects/1', undefined));
+      assert(projects.get.calledWithExactly('/projects/1', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
+      projects.get = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       projects.findById(id, params);
-      assert(this.get.calledWithExactly('/projects/1', params));
+      assert(projects.get.calledWithExactly('/projects/1', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
+      projects.get = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       projects.findById(id, params);
-      assert(this.get.calledWithExactly('/projects/1', params));
+      assert(projects.get.calledWithExactly('/projects/1', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
+      projects.get = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       projects.findById(id, params);
-      assert(this.get.calledWithExactly('/projects/NaN', params));
+      assert(projects.get.calledWithExactly('/projects/NaN', params));
     });
   });
 
@@ -126,46 +136,54 @@ describe('Projects', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
+      projects.getCollection = sinon.stub();
       var id = 1;
       projects.findByWorkspace(id);
       assert(
-        dispatcher.get.calledWithExactly('/workspaces/1/projects', undefined));
+          projects.getCollection.calledWithExactly(
+              '/workspaces/1/projects', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
+      projects.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       projects.findByWorkspace(id, params);
       assert(
-        dispatcher.get.calledWithExactly('/workspaces/1/projects', params));
+          projects.getCollection.calledWithExactly(
+              '/workspaces/1/projects', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
+      projects.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       projects.findByWorkspace(id, params);
       assert(
-        dispatcher.get.calledWithExactly('/workspaces/1/projects', params));
+          projects.getCollection.calledWithExactly(
+              '/workspaces/1/projects', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
+      projects.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       projects.findByWorkspace(id, params);
       assert(
-        dispatcher.get.calledWithExactly('/workspaces/NaN/projects', params));
+          projects.getCollection.calledWithExactly(
+              '/workspaces/NaN/projects', params));
     });
   });
 
@@ -173,34 +191,37 @@ describe('Projects', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
+      projects.put = sinon.stub();
       var id = 1;
       var data = {
         name: 'Test'
       };
       projects.update(id, data);
-      assert(this.put.calledWithExactly('/projects/1', data));
+      assert(projects.put.calledWithExactly('/projects/1', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
+      projects.put = sinon.stub();
       var id = '1';
       var data = {
         name: 'Test'
       };
       projects.update(id, data);
-      assert(this.put.calledWithExactly('/projects/1', data));
+      assert(projects.put.calledWithExactly('/projects/1', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
+      projects.put = sinon.stub();
       var id = 'foobar';
       var data = {
         name: 'Test'
       };
       projects.update(id, data);
-      assert(this.put.calledWithExactly('/projects/NaN', data));
+      assert(projects.put.calledWithExactly('/projects/NaN', data));
     });
   });
 
@@ -208,25 +229,28 @@ describe('Projects', function() {
     it('should handle the deletion', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
+      projects.delete = sinon.stub();
       var id = 1;
-      projects.delete(id);
-      assert(this.delete.calledWithExactly('/projects/1'));
+      projects.destroy(id);
+      assert(projects.delete.calledWithExactly('/projects/1'));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
+      projects.delete = sinon.stub();
       var id = '1';
-      projects.delete(id);
-      assert(this.delete.calledWithExactly('/projects/1'));
+      projects.destroy(id);
+      assert(projects.delete.calledWithExactly('/projects/1'));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
+      projects.delete = sinon.stub();
       var id = 'foobar';
-      projects.delete(id);
-      assert(this.delete.calledWithExactly('/projects/NaN'));
+      projects.destroy(id);
+      assert(projects.delete.calledWithExactly('/projects/NaN'));
     });
   });
 });

--- a/test/resources/projects_spec.js
+++ b/test/resources/projects_spec.js
@@ -16,12 +16,12 @@ describe('Projects', function() {
     it('should handle the creation', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
-      projects.post = sinon.stub();
+      projects.dispatchPost = sinon.stub();
       var data = {
         name: 'Test'
       };
       projects.create(data);
-      assert(projects.post.calledWithExactly('/projects', data));
+      assert(projects.dispatchPost.calledWithExactly('/projects', data));
     });
   });
 
@@ -29,38 +29,43 @@ describe('Projects', function() {
     it('should handle the creation', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
-      projects.post = sinon.stub();
+      projects.dispatchPost = sinon.stub();
       var id = 1;
       var data = {
         name: 'Test'
       };
       projects.createInWorkspace(id, data);
-      assert(projects.post.calledWithExactly('/workspaces/1/projects', data));
+      assert(
+          projects.dispatchPost.calledWithExactly(
+              '/workspaces/1/projects', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
-      projects.post = sinon.stub();
+      projects.dispatchPost = sinon.stub();
       var id = '1';
       var data = {
         name: 'Test'
       };
       projects.createInWorkspace(id, data);
-      assert(projects.post.calledWithExactly('/workspaces/1/projects', data));
+      assert(
+          projects.dispatchPost.calledWithExactly(
+              '/workspaces/1/projects', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
-      projects.post = sinon.stub();
+      projects.dispatchPost = sinon.stub();
       var id = 'foobar';
       var data = {
         name: 'Test'
       };
       projects.createInWorkspace(id, data);
       assert(
-          projects.post.calledWithExactly('/workspaces/NaN/projects', data));
+          projects.dispatchPost.calledWithExactly(
+              '/workspaces/NaN/projects', data));
     });
   });
 
@@ -68,20 +73,24 @@ describe('Projects', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
-      projects.getCollection = sinon.stub();
+      projects.dispatchGetCollection = sinon.stub();
       projects.findAll();
-      assert(projects.getCollection.calledWithExactly('/projects', undefined));
+      assert(
+          projects.dispatchGetCollection.calledWithExactly(
+              '/projects', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
-      projects.getCollection = sinon.stub();
+      projects.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       projects.findAll(params);
-      assert(projects.getCollection.calledWithExactly('/projects', params));
+      assert(
+          projects.dispatchGetCollection.calledWithExactly(
+              '/projects', params));
     });
   });
 
@@ -89,46 +98,46 @@ describe('Projects', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
-      projects.get = sinon.stub();
+      projects.dispatchGet = sinon.stub();
       var id = 1;
       projects.findById(id);
-      assert(projects.get.calledWithExactly('/projects/1', undefined));
+      assert(projects.dispatchGet.calledWithExactly('/projects/1', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
-      projects.get = sinon.stub();
+      projects.dispatchGet = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       projects.findById(id, params);
-      assert(projects.get.calledWithExactly('/projects/1', params));
+      assert(projects.dispatchGet.calledWithExactly('/projects/1', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
-      projects.get = sinon.stub();
+      projects.dispatchGet = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       projects.findById(id, params);
-      assert(projects.get.calledWithExactly('/projects/1', params));
+      assert(projects.dispatchGet.calledWithExactly('/projects/1', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
-      projects.get = sinon.stub();
+      projects.dispatchGet = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       projects.findById(id, params);
-      assert(projects.get.calledWithExactly('/projects/NaN', params));
+      assert(projects.dispatchGet.calledWithExactly('/projects/NaN', params));
     });
   });
 
@@ -136,53 +145,53 @@ describe('Projects', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
-      projects.getCollection = sinon.stub();
+      projects.dispatchGetCollection = sinon.stub();
       var id = 1;
       projects.findByWorkspace(id);
       assert(
-          projects.getCollection.calledWithExactly(
+          projects.dispatchGetCollection.calledWithExactly(
               '/workspaces/1/projects', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
-      projects.getCollection = sinon.stub();
+      projects.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       projects.findByWorkspace(id, params);
       assert(
-          projects.getCollection.calledWithExactly(
+          projects.dispatchGetCollection.calledWithExactly(
               '/workspaces/1/projects', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
-      projects.getCollection = sinon.stub();
+      projects.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       projects.findByWorkspace(id, params);
       assert(
-          projects.getCollection.calledWithExactly(
+          projects.dispatchGetCollection.calledWithExactly(
               '/workspaces/1/projects', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
-      projects.getCollection = sinon.stub();
+      projects.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       projects.findByWorkspace(id, params);
       assert(
-          projects.getCollection.calledWithExactly(
+          projects.dispatchGetCollection.calledWithExactly(
               '/workspaces/NaN/projects', params));
     });
   });
@@ -191,37 +200,37 @@ describe('Projects', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
-      projects.put = sinon.stub();
+      projects.dispatchPut = sinon.stub();
       var id = 1;
       var data = {
         name: 'Test'
       };
       projects.update(id, data);
-      assert(projects.put.calledWithExactly('/projects/1', data));
+      assert(projects.dispatchPut.calledWithExactly('/projects/1', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
-      projects.put = sinon.stub();
+      projects.dispatchPut = sinon.stub();
       var id = '1';
       var data = {
         name: 'Test'
       };
       projects.update(id, data);
-      assert(projects.put.calledWithExactly('/projects/1', data));
+      assert(projects.dispatchPut.calledWithExactly('/projects/1', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
-      projects.put = sinon.stub();
+      projects.dispatchPut = sinon.stub();
       var id = 'foobar';
       var data = {
         name: 'Test'
       };
       projects.update(id, data);
-      assert(projects.put.calledWithExactly('/projects/NaN', data));
+      assert(projects.dispatchPut.calledWithExactly('/projects/NaN', data));
     });
   });
 
@@ -229,28 +238,28 @@ describe('Projects', function() {
     it('should handle the deletion', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
-      projects.delete = sinon.stub();
+      projects.dispatchDelete = sinon.stub();
       var id = 1;
-      projects.destroy(id);
-      assert(projects.delete.calledWithExactly('/projects/1'));
+      projects.delete(id);
+      assert(projects.dispatchDelete.calledWithExactly('/projects/1'));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
-      projects.delete = sinon.stub();
+      projects.dispatchDelete = sinon.stub();
       var id = '1';
-      projects.destroy(id);
-      assert(projects.delete.calledWithExactly('/projects/1'));
+      projects.delete(id);
+      assert(projects.dispatchDelete.calledWithExactly('/projects/1'));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var projects = new Projects(dispatcher);
-      projects.delete = sinon.stub();
+      projects.dispatchDelete = sinon.stub();
       var id = 'foobar';
-      projects.destroy(id);
-      assert(projects.delete.calledWithExactly('/projects/NaN'));
+      projects.delete(id);
+      assert(projects.dispatchDelete.calledWithExactly('/projects/NaN'));
     });
   });
 });

--- a/test/resources/projects_spec.js
+++ b/test/resources/projects_spec.js
@@ -14,49 +14,41 @@ describe('Projects', function() {
 
   describe('#create', function() {
     it('should handle the creation', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var projects = new Projects(dispatcher);
       var data = {
         name: 'Test'
       };
       projects.create(data);
-      assert(dispatcher.post.calledWithExactly('/projects', data));
+      assert(this.post.calledWithExactly('/projects', data));
     });
   });
 
   describe('#createInWorkspace', function() {
     it('should handle the creation', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var projects = new Projects(dispatcher);
       var id = 1;
       var data = {
         name: 'Test'
       };
       projects.createInWorkspace(id, data);
-      assert(dispatcher.post.calledWithExactly('/workspaces/1/projects', data));
+      assert(this.post.calledWithExactly('/workspaces/1/projects', data));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var projects = new Projects(dispatcher);
       var id = '1';
       var data = {
         name: 'Test'
       };
       projects.createInWorkspace(id, data);
-      assert(dispatcher.post.calledWithExactly('/workspaces/1/projects', data));
+      assert(this.post.calledWithExactly('/workspaces/1/projects', data));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var projects = new Projects(dispatcher);
       var id = 'foobar';
       var data = {
@@ -70,83 +62,69 @@ describe('Projects', function() {
 
   describe('#findAll', function() {
     it('should handle without params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var projects = new Projects(dispatcher);
       projects.findAll();
-      assert(dispatcher.get.calledWithExactly('/projects', undefined));
+      assert(this.get.calledWithExactly('/projects', undefined));
     });
 
     it('should handle with params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var projects = new Projects(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       projects.findAll(params);
-      assert(dispatcher.get.calledWithExactly('/projects', params));
+      assert(this.get.calledWithExactly('/projects', params));
     });
   });
 
   describe('#findById', function() {
     it('should handle without params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var projects = new Projects(dispatcher);
       var id = 1;
       projects.findById(id);
-      assert(dispatcher.get.calledWithExactly('/projects/1', undefined));
+      assert(this.get.calledWithExactly('/projects/1', undefined));
     });
 
     it('should handle with params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var projects = new Projects(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       projects.findById(id, params);
-      assert(dispatcher.get.calledWithExactly('/projects/1', params));
+      assert(this.get.calledWithExactly('/projects/1', params));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var projects = new Projects(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       projects.findById(id, params);
-      assert(dispatcher.get.calledWithExactly('/projects/1', params));
+      assert(this.get.calledWithExactly('/projects/1', params));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var projects = new Projects(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       projects.findById(id, params);
-      assert(dispatcher.get.calledWithExactly('/projects/NaN', params));
+      assert(this.get.calledWithExactly('/projects/NaN', params));
     });
   });
 
   describe('#findByWorkspace', function() {
     it('should handle without params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var projects = new Projects(dispatcher);
       var id = 1;
       projects.findByWorkspace(id);
@@ -155,9 +133,7 @@ describe('Projects', function() {
     });
 
     it('should handle with params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var projects = new Projects(dispatcher);
       var params = {
         'opt_fields': 'id,name'
@@ -169,9 +145,7 @@ describe('Projects', function() {
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var projects = new Projects(dispatcher);
       var params = {
         'opt_fields': 'id,name'
@@ -183,9 +157,7 @@ describe('Projects', function() {
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var projects = new Projects(dispatcher);
       var params = {
         'opt_fields': 'id,name'
@@ -199,74 +171,62 @@ describe('Projects', function() {
 
   describe('#update', function() {
     it('should handle the update', function() {
-      var dispatcher = {
-        put: sinon.stub()
-      };
+      var dispatcher = {};
       var projects = new Projects(dispatcher);
       var id = 1;
       var data = {
         name: 'Test'
       };
       projects.update(id, data);
-      assert(dispatcher.put.calledWithExactly('/projects/1', data));
+      assert(this.put.calledWithExactly('/projects/1', data));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        put: sinon.stub()
-      };
+      var dispatcher = {};
       var projects = new Projects(dispatcher);
       var id = '1';
       var data = {
         name: 'Test'
       };
       projects.update(id, data);
-      assert(dispatcher.put.calledWithExactly('/projects/1', data));
+      assert(this.put.calledWithExactly('/projects/1', data));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        put: sinon.stub()
-      };
+      var dispatcher = {};
       var projects = new Projects(dispatcher);
       var id = 'foobar';
       var data = {
         name: 'Test'
       };
       projects.update(id, data);
-      assert(dispatcher.put.calledWithExactly('/projects/NaN', data));
+      assert(this.put.calledWithExactly('/projects/NaN', data));
     });
   });
 
   describe('#delete', function() {
     it('should handle the deletion', function() {
-      var dispatcher = {
-        delete: sinon.stub()
-      };
+      var dispatcher = {};
       var projects = new Projects(dispatcher);
       var id = 1;
       projects.delete(id);
-      assert(dispatcher.delete.calledWithExactly('/projects/1'));
+      assert(this.delete.calledWithExactly('/projects/1'));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        delete: sinon.stub()
-      };
+      var dispatcher = {};
       var projects = new Projects(dispatcher);
       var id = '1';
       projects.delete(id);
-      assert(dispatcher.delete.calledWithExactly('/projects/1'));
+      assert(this.delete.calledWithExactly('/projects/1'));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        delete: sinon.stub()
-      };
+      var dispatcher = {};
       var projects = new Projects(dispatcher);
       var id = 'foobar';
       projects.delete(id);
-      assert(dispatcher.delete.calledWithExactly('/projects/NaN'));
+      assert(this.delete.calledWithExactly('/projects/NaN'));
     });
   });
 });

--- a/test/resources/resource_spec.js
+++ b/test/resources/resource_spec.js
@@ -1,0 +1,40 @@
+/* jshint mocha:true */
+var assert = require('assert');
+var sinon = require('sinon');
+var Bluebird = require('bluebird');
+var Resource = require('../../lib/resources/resource');
+
+describe('Resource', function() {
+  describe('#new', function() {
+    it('should add the dispatcher to itself', function() {
+      var dispatcher = sinon.stub();
+      var users = new Resource(dispatcher);
+      assert.equal(users.dispatcher, dispatcher);
+    });
+  });
+
+  describe('#get', function() {
+    it('should call dispatcher get and unwrap', function() {
+      var dispatcher = {
+        get: sinon.stub()
+      };
+      var promise = Bluebird.resolved();
+      dispatcher.get.onFirstCall().returns(promise);
+      Resource.unwrap = sinon.stub();  //xcxc revert?
+      var resource = new Resource(dispatcher);
+
+      var path = '/path';
+      var query = {};
+      var options = {};
+      resource.get(path, query, options);
+
+      assert(dispatcher.get.calledWithExactly(path, query, options));
+      assert(Resource.unwrap.calledWithExactly(promise));
+    });
+  });
+
+  //xcxc put, post, etc.
+
+  //xcxc static methods
+
+});

--- a/test/resources/resource_spec.js
+++ b/test/resources/resource_spec.js
@@ -5,6 +5,16 @@ var Bluebird = require('bluebird');
 var Resource = require('../../lib/resources/resource');
 
 describe('Resource', function() {
+
+  var sandbox;
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
   describe('#new', function() {
     it('should add the dispatcher to itself', function() {
       var dispatcher = sinon.stub();
@@ -13,28 +23,106 @@ describe('Resource', function() {
     });
   });
 
-  describe('#get', function() {
+  describe('#dispatchGet', function() {
     it('should call dispatcher get and unwrap', function() {
       var dispatcher = {
         get: sinon.stub()
       };
-      var promise = Bluebird.resolved();
+      var promise = Bluebird.resolve();
       dispatcher.get.onFirstCall().returns(promise);
-      Resource.unwrap = sinon.stub();  //xcxc revert?
+      sandbox.stub(Resource, 'unwrap');
       var resource = new Resource(dispatcher);
 
       var path = '/path';
       var query = {};
       var options = {};
-      resource.get(path, query, options);
+      resource.dispatchGet(path, query, options);
 
       assert(dispatcher.get.calledWithExactly(path, query, options));
       assert(Resource.unwrap.calledWithExactly(promise));
     });
   });
 
-  //xcxc put, post, etc.
+  describe('#dispatchGetCollection', function() {
+    it('should call dispatcher get with limit', function() {
+      var dispatcher = {
+        get: sinon.stub()
+      };
+      var promise = Bluebird.resolve();
+      dispatcher.get.onFirstCall().returns(promise);
+      sandbox.stub(Resource, 'unwrap');
+      var resource = new Resource(dispatcher);
 
-  //xcxc static methods
+      var path = '/path';
+      var query = {};
+      var options = {};
+      resource.dispatchGetCollection(path, query, options);
+
+      assert(dispatcher.get.called);
+      assert.equal(dispatcher.get.firstCall.args[0], path);
+      assert.deepEqual(dispatcher.get.firstCall.args[1], { limit: 50 });
+      assert.equal(dispatcher.get.firstCall.args[2], options);
+      assert(!Resource.unwrap.called);
+    });
+  });
+
+  describe('#dispatchPost', function() {
+    it('should call dispatcher post and unwrap', function() {
+      var dispatcher = {
+        post: sinon.stub()
+      };
+      var promise = Bluebird.resolve();
+      dispatcher.post.onFirstCall().returns(promise);
+      sandbox.stub(Resource, 'unwrap');
+      var resource = new Resource(dispatcher);
+
+      var path = '/path';
+      var query = {};
+      var options = {};
+      resource.dispatchPost(path, query, options);
+
+      assert(dispatcher.post.calledWithExactly(path, query, options));
+      assert(Resource.unwrap.calledWithExactly(promise));
+    });
+  });
+
+  describe('#dispatchPut', function() {
+    it('should call dispatcher put and unwrap', function() {
+      var dispatcher = {
+        put: sinon.stub()
+      };
+      var promise = Bluebird.resolve();
+      dispatcher.put.onFirstCall().returns(promise);
+      sandbox.stub(Resource, 'unwrap');
+      var resource = new Resource(dispatcher);
+
+      var path = '/path';
+      var query = {};
+      var options = {};
+      resource.dispatchPut(path, query, options);
+
+      assert(dispatcher.put.calledWithExactly(path, query, options));
+      assert(Resource.unwrap.calledWithExactly(promise));
+    });
+  });
+
+  describe('#dispatchDelete', function() {
+    it('should call dispatcher delete and unwrap', function() {
+      var dispatcher = {
+        delete: sinon.stub()
+      };
+      var promise = Bluebird.resolve();
+      dispatcher.delete.onFirstCall().returns(promise);
+      sandbox.stub(Resource, 'unwrap');
+      var resource = new Resource(dispatcher);
+
+      var path = '/path';
+      var options = {};
+      resource.dispatchDelete(path, options);
+
+      assert(dispatcher.delete.calledWithExactly(path, options));
+      assert(Resource.unwrap.calledWithExactly(promise));
+    });
+  });
 
 });

--- a/test/resources/stories_spec.js
+++ b/test/resources/stories_spec.js
@@ -16,42 +16,46 @@ describe('Stories', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
+      stories.get = sinon.stub();
       var id = 1;
       stories.findById(id);
-      assert(this.get.calledWithExactly('/stories/1', undefined));
+      assert(stories.get.calledWithExactly('/stories/1', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
+      stories.get = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       stories.findById(id, params);
-      assert(this.get.calledWithExactly('/stories/1', params));
+      assert(stories.get.calledWithExactly('/stories/1', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
+      stories.get = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       stories.findById(id, params);
-      assert(this.get.calledWithExactly('/stories/1', params));
+      assert(stories.get.calledWithExactly('/stories/1', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
+      stories.get = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       stories.findById(id, params);
-      assert(this.get.calledWithExactly('/stories/NaN', params));
+      assert(stories.get.calledWithExactly('/stories/NaN', params));
     });
   });
 
@@ -59,44 +63,53 @@ describe('Stories', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
+      stories.getCollection = sinon.stub();
       var id = 1;
       stories.findByTask(id);
       assert(
-        dispatcher.get.calledWithExactly('/tasks/1/stories', undefined));
+        stories.getCollection.calledWithExactly(
+            '/tasks/1/stories', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
+      stories.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       stories.findByTask(id, params);
-      assert(this.get.calledWithExactly('/tasks/1/stories', params));
+      assert(
+          stories.getCollection.calledWithExactly(
+              '/tasks/1/stories', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
+      stories.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       stories.findByTask(id, params);
-      assert(this.get.calledWithExactly('/tasks/1/stories', params));
+      assert(
+          stories.getCollection.calledWithExactly('/tasks/1/stories', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
+      stories.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       stories.findByTask(id, params);
       assert(
-        dispatcher.get.calledWithExactly('/tasks/NaN/stories', params));
+          stories.getCollection.calledWithExactly(
+              '/tasks/NaN/stories', params));
     });
   });
 
@@ -104,34 +117,37 @@ describe('Stories', function() {
     it('should handle the creation', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
+      stories.post = sinon.stub();
       var id = 1;
       var data = {
         text: 'Test'
       };
       stories.createOnTask(id, data);
-      assert(this.post.calledWithExactly('/tasks/1/stories', data));
+      assert(stories.post.calledWithExactly('/tasks/1/stories', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
+      stories.post = sinon.stub();
       var id = '1';
       var data = {
         text: 'Test'
       };
       stories.createOnTask(id, data);
-      assert(this.post.calledWithExactly('/tasks/1/stories', data));
+      assert(stories.post.calledWithExactly('/tasks/1/stories', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
+      stories.post = sinon.stub();
       var id = 'foobar';
       var data = {
         text: 'Test'
       };
       stories.createOnTask(id, data);
-      assert(this.post.calledWithExactly('/tasks/NaN/stories', data));
+      assert(stories.post.calledWithExactly('/tasks/NaN/stories', data));
     });
   });
 });

--- a/test/resources/stories_spec.js
+++ b/test/resources/stories_spec.js
@@ -16,46 +16,46 @@ describe('Stories', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
-      stories.get = sinon.stub();
+      stories.dispatchGet = sinon.stub();
       var id = 1;
       stories.findById(id);
-      assert(stories.get.calledWithExactly('/stories/1', undefined));
+      assert(stories.dispatchGet.calledWithExactly('/stories/1', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
-      stories.get = sinon.stub();
+      stories.dispatchGet = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       stories.findById(id, params);
-      assert(stories.get.calledWithExactly('/stories/1', params));
+      assert(stories.dispatchGet.calledWithExactly('/stories/1', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
-      stories.get = sinon.stub();
+      stories.dispatchGet = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       stories.findById(id, params);
-      assert(stories.get.calledWithExactly('/stories/1', params));
+      assert(stories.dispatchGet.calledWithExactly('/stories/1', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
-      stories.get = sinon.stub();
+      stories.dispatchGet = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       stories.findById(id, params);
-      assert(stories.get.calledWithExactly('/stories/NaN', params));
+      assert(stories.dispatchGet.calledWithExactly('/stories/NaN', params));
     });
   });
 
@@ -63,52 +63,53 @@ describe('Stories', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
-      stories.getCollection = sinon.stub();
+      stories.dispatchGetCollection = sinon.stub();
       var id = 1;
       stories.findByTask(id);
       assert(
-        stories.getCollection.calledWithExactly(
+        stories.dispatchGetCollection.calledWithExactly(
             '/tasks/1/stories', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
-      stories.getCollection = sinon.stub();
+      stories.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       stories.findByTask(id, params);
       assert(
-          stories.getCollection.calledWithExactly(
+          stories.dispatchGetCollection.calledWithExactly(
               '/tasks/1/stories', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
-      stories.getCollection = sinon.stub();
+      stories.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       stories.findByTask(id, params);
       assert(
-          stories.getCollection.calledWithExactly('/tasks/1/stories', params));
+          stories.dispatchGetCollection.calledWithExactly(
+              '/tasks/1/stories', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
-      stories.getCollection = sinon.stub();
+      stories.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       stories.findByTask(id, params);
       assert(
-          stories.getCollection.calledWithExactly(
+          stories.dispatchGetCollection.calledWithExactly(
               '/tasks/NaN/stories', params));
     });
   });
@@ -117,37 +118,38 @@ describe('Stories', function() {
     it('should handle the creation', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
-      stories.post = sinon.stub();
+      stories.dispatchPost = sinon.stub();
       var id = 1;
       var data = {
         text: 'Test'
       };
       stories.createOnTask(id, data);
-      assert(stories.post.calledWithExactly('/tasks/1/stories', data));
+      assert(stories.dispatchPost.calledWithExactly('/tasks/1/stories', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
-      stories.post = sinon.stub();
+      stories.dispatchPost = sinon.stub();
       var id = '1';
       var data = {
         text: 'Test'
       };
       stories.createOnTask(id, data);
-      assert(stories.post.calledWithExactly('/tasks/1/stories', data));
+      assert(stories.dispatchPost.calledWithExactly('/tasks/1/stories', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var stories = new Stories(dispatcher);
-      stories.post = sinon.stub();
+      stories.dispatchPost = sinon.stub();
       var id = 'foobar';
       var data = {
         text: 'Test'
       };
       stories.createOnTask(id, data);
-      assert(stories.post.calledWithExactly('/tasks/NaN/stories', data));
+      assert(
+          stories.dispatchPost.calledWithExactly('/tasks/NaN/stories', data));
     });
   });
 });

--- a/test/resources/stories_spec.js
+++ b/test/resources/stories_spec.js
@@ -14,60 +14,50 @@ describe('Stories', function() {
 
   describe('#findById', function() {
     it('should handle without params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var stories = new Stories(dispatcher);
       var id = 1;
       stories.findById(id);
-      assert(dispatcher.get.calledWithExactly('/stories/1', undefined));
+      assert(this.get.calledWithExactly('/stories/1', undefined));
     });
 
     it('should handle with params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var stories = new Stories(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       stories.findById(id, params);
-      assert(dispatcher.get.calledWithExactly('/stories/1', params));
+      assert(this.get.calledWithExactly('/stories/1', params));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var stories = new Stories(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       stories.findById(id, params);
-      assert(dispatcher.get.calledWithExactly('/stories/1', params));
+      assert(this.get.calledWithExactly('/stories/1', params));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var stories = new Stories(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       stories.findById(id, params);
-      assert(dispatcher.get.calledWithExactly('/stories/NaN', params));
+      assert(this.get.calledWithExactly('/stories/NaN', params));
     });
   });
 
   describe('#findByTask', function() {
     it('should handle without params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var stories = new Stories(dispatcher);
       var id = 1;
       stories.findByTask(id);
@@ -76,35 +66,29 @@ describe('Stories', function() {
     });
 
     it('should handle with params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var stories = new Stories(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       stories.findByTask(id, params);
-      assert(dispatcher.get.calledWithExactly('/tasks/1/stories', params));
+      assert(this.get.calledWithExactly('/tasks/1/stories', params));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var stories = new Stories(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       stories.findByTask(id, params);
-      assert(dispatcher.get.calledWithExactly('/tasks/1/stories', params));
+      assert(this.get.calledWithExactly('/tasks/1/stories', params));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var stories = new Stories(dispatcher);
       var params = {
         'opt_fields': 'id,name'
@@ -118,42 +102,36 @@ describe('Stories', function() {
 
   describe('#createOnTask', function() {
     it('should handle the creation', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var stories = new Stories(dispatcher);
       var id = 1;
       var data = {
         text: 'Test'
       };
       stories.createOnTask(id, data);
-      assert(dispatcher.post.calledWithExactly('/tasks/1/stories', data));
+      assert(this.post.calledWithExactly('/tasks/1/stories', data));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var stories = new Stories(dispatcher);
       var id = '1';
       var data = {
         text: 'Test'
       };
       stories.createOnTask(id, data);
-      assert(dispatcher.post.calledWithExactly('/tasks/1/stories', data));
+      assert(this.post.calledWithExactly('/tasks/1/stories', data));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var stories = new Stories(dispatcher);
       var id = 'foobar';
       var data = {
         text: 'Test'
       };
       stories.createOnTask(id, data);
-      assert(dispatcher.post.calledWithExactly('/tasks/NaN/stories', data));
+      assert(this.post.calledWithExactly('/tasks/NaN/stories', data));
     });
   });
 });

--- a/test/resources/tags_spec.js
+++ b/test/resources/tags_spec.js
@@ -16,12 +16,12 @@ describe('Tags', function() {
     it('should handle the creation', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
-      tags.post = sinon.stub();
+      tags.dispatchPost = sinon.stub();
       var data = {
         name: 'Test'
       };
       tags.create(data);
-      assert(tags.post.calledWithExactly('/tags', data));
+      assert(tags.dispatchPost.calledWithExactly('/tags', data));
     });
   });
 
@@ -29,37 +29,37 @@ describe('Tags', function() {
     it('should handle the creation', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
-      tags.post = sinon.stub();
+      tags.dispatchPost = sinon.stub();
       var id = 1;
       var data = {
         name: 'Test'
       };
       tags.createInWorkspace(id, data);
-      assert(tags.post.calledWithExactly('/workspaces/1/tags', data));
+      assert(tags.dispatchPost.calledWithExactly('/workspaces/1/tags', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
-      tags.post = sinon.stub();
+      tags.dispatchPost = sinon.stub();
       var id = '1';
       var data = {
         name: 'Test'
       };
       tags.createInWorkspace(id, data);
-      assert(tags.post.calledWithExactly('/workspaces/1/tags', data));
+      assert(tags.dispatchPost.calledWithExactly('/workspaces/1/tags', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
-      tags.post = sinon.stub();
+      tags.dispatchPost = sinon.stub();
       var id = 'foobar';
       var data = {
         name: 'Test'
       };
       tags.createInWorkspace(id, data);
-      assert(tags.post.calledWithExactly('/workspaces/NaN/tags', data));
+      assert(tags.dispatchPost.calledWithExactly('/workspaces/NaN/tags', data));
     });
   });
 
@@ -67,20 +67,20 @@ describe('Tags', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
-      tags.getCollection = sinon.stub();
+      tags.dispatchGetCollection = sinon.stub();
       tags.findAll();
-      assert(tags.getCollection.calledWithExactly('/tags', undefined));
+      assert(tags.dispatchGetCollection.calledWithExactly('/tags', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
-      tags.getCollection = sinon.stub();
+      tags.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       tags.findAll(params);
-      assert(tags.getCollection.calledWithExactly('/tags', params));
+      assert(tags.dispatchGetCollection.calledWithExactly('/tags', params));
     });
   });
 
@@ -88,46 +88,46 @@ describe('Tags', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
-      tags.get = sinon.stub();
+      tags.dispatchGet = sinon.stub();
       var id = 1;
       tags.findById(id);
-      assert(tags.get.calledWithExactly('/tags/1', undefined));
+      assert(tags.dispatchGet.calledWithExactly('/tags/1', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
-      tags.get = sinon.stub();
+      tags.dispatchGet = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       tags.findById(id, params);
-      assert(tags.get.calledWithExactly('/tags/1', params));
+      assert(tags.dispatchGet.calledWithExactly('/tags/1', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
-      tags.get = sinon.stub();
+      tags.dispatchGet = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       tags.findById(id, params);
-      assert(tags.get.calledWithExactly('/tags/1', params));
+      assert(tags.dispatchGet.calledWithExactly('/tags/1', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
-      tags.get = sinon.stub();
+      tags.dispatchGet = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       tags.findById(id, params);
-      assert(tags.get.calledWithExactly('/tags/NaN', params));
+      assert(tags.dispatchGet.calledWithExactly('/tags/NaN', params));
     });
   });
 
@@ -135,50 +135,54 @@ describe('Tags', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
-      tags.getCollection = sinon.stub();
+      tags.dispatchGetCollection = sinon.stub();
       var id = 1;
       tags.findByWorkspace(id);
       assert(
-        tags.getCollection.calledWithExactly('/workspaces/1/tags', undefined));
+          tags.dispatchGetCollection.calledWithExactly(
+              '/workspaces/1/tags', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
-      tags.getCollection = sinon.stub();
+      tags.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       tags.findByWorkspace(id, params);
       assert(
-          tags.getCollection.calledWithExactly('/workspaces/1/tags', params));
+          tags.dispatchGetCollection.calledWithExactly(
+              '/workspaces/1/tags', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
-      tags.getCollection = sinon.stub();
+      tags.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       tags.findByWorkspace(id, params);
       assert(
-          tags.getCollection.calledWithExactly('/workspaces/1/tags', params));
+          tags.dispatchGetCollection.calledWithExactly(
+              '/workspaces/1/tags', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
-      tags.getCollection = sinon.stub();
+      tags.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       tags.findByWorkspace(id, params);
       assert(
-          tags.getCollection.calledWithExactly('/workspaces/NaN/tags', params));
+          tags.dispatchGetCollection.calledWithExactly(
+              '/workspaces/NaN/tags', params));
     });
   });
 
@@ -186,37 +190,37 @@ describe('Tags', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
-      tags.put = sinon.stub();
+      tags.dispatchPut = sinon.stub();
       var id = 1;
       var data = {
         name: 'Test'
       };
       tags.update(id, data);
-      assert(tags.put.calledWithExactly('/tags/1', data));
+      assert(tags.dispatchPut.calledWithExactly('/tags/1', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
-      tags.put = sinon.stub();
+      tags.dispatchPut = sinon.stub();
       var id = '1';
       var data = {
         name: 'Test'
       };
       tags.update(id, data);
-      assert(tags.put.calledWithExactly('/tags/1', data));
+      assert(tags.dispatchPut.calledWithExactly('/tags/1', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
-      tags.put = sinon.stub();
+      tags.dispatchPut = sinon.stub();
       var id = 'foobar';
       var data = {
         name: 'Test'
       };
       tags.update(id, data);
-      assert(tags.put.calledWithExactly('/tags/NaN', data));
+      assert(tags.dispatchPut.calledWithExactly('/tags/NaN', data));
     });
   });
 });

--- a/test/resources/tags_spec.js
+++ b/test/resources/tags_spec.js
@@ -16,11 +16,12 @@ describe('Tags', function() {
     it('should handle the creation', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
+      tags.post = sinon.stub();
       var data = {
         name: 'Test'
       };
       tags.create(data);
-      assert(this.post.calledWithExactly('/tags', data));
+      assert(tags.post.calledWithExactly('/tags', data));
     });
   });
 
@@ -28,34 +29,37 @@ describe('Tags', function() {
     it('should handle the creation', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
+      tags.post = sinon.stub();
       var id = 1;
       var data = {
         name: 'Test'
       };
       tags.createInWorkspace(id, data);
-      assert(this.post.calledWithExactly('/workspaces/1/tags', data));
+      assert(tags.post.calledWithExactly('/workspaces/1/tags', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
+      tags.post = sinon.stub();
       var id = '1';
       var data = {
         name: 'Test'
       };
       tags.createInWorkspace(id, data);
-      assert(this.post.calledWithExactly('/workspaces/1/tags', data));
+      assert(tags.post.calledWithExactly('/workspaces/1/tags', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
+      tags.post = sinon.stub();
       var id = 'foobar';
       var data = {
         name: 'Test'
       };
       tags.createInWorkspace(id, data);
-      assert(this.post.calledWithExactly('/workspaces/NaN/tags', data));
+      assert(tags.post.calledWithExactly('/workspaces/NaN/tags', data));
     });
   });
 
@@ -63,18 +67,20 @@ describe('Tags', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
+      tags.getCollection = sinon.stub();
       tags.findAll();
-      assert(this.get.calledWithExactly('/tags', undefined));
+      assert(tags.get.calledWithExactly('/tags', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
+      tags.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       tags.findAll(params);
-      assert(this.get.calledWithExactly('/tags', params));
+      assert(tags.get.calledWithExactly('/tags', params));
     });
   });
 
@@ -82,42 +88,46 @@ describe('Tags', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
+      tags.get = sinon.stub();
       var id = 1;
       tags.findById(id);
-      assert(this.get.calledWithExactly('/tags/1', undefined));
+      assert(tags.get.calledWithExactly('/tags/1', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
+      tags.get = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       tags.findById(id, params);
-      assert(this.get.calledWithExactly('/tags/1', params));
+      assert(tags.get.calledWithExactly('/tags/1', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
+      tags.get = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       tags.findById(id, params);
-      assert(this.get.calledWithExactly('/tags/1', params));
+      assert(tags.get.calledWithExactly('/tags/1', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
+      tags.get = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       tags.findById(id, params);
-      assert(this.get.calledWithExactly('/tags/NaN', params));
+      assert(tags.get.calledWithExactly('/tags/NaN', params));
     });
   });
 
@@ -125,43 +135,50 @@ describe('Tags', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
+      tags.getCollection = sinon.stub();
       var id = 1;
       tags.findByWorkspace(id);
       assert(
-        dispatcher.get.calledWithExactly('/workspaces/1/tags', undefined));
+        tags.getCollection.calledWithExactly('/workspaces/1/tags', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
+      tags.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       tags.findByWorkspace(id, params);
-      assert(this.get.calledWithExactly('/workspaces/1/tags', params));
+      assert(
+          tags.getCollection.calledWithExactly('/workspaces/1/tags', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
+      tags.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       tags.findByWorkspace(id, params);
-      assert(this.get.calledWithExactly('/workspaces/1/tags', params));
+      assert(
+          tags.getCollection.calledWithExactly('/workspaces/1/tags', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
+      tags.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       tags.findByWorkspace(id, params);
-      assert(this.get.calledWithExactly('/workspaces/NaN/tags', params));
+      assert(
+          tags.getCollection.calledWithExactly('/workspaces/NaN/tags', params));
     });
   });
 
@@ -169,34 +186,37 @@ describe('Tags', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
+      tags.put = sinon.stub();
       var id = 1;
       var data = {
         name: 'Test'
       };
       tags.update(id, data);
-      assert(this.put.calledWithExactly('/tags/1', data));
+      assert(tags.put.calledWithExactly('/tags/1', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
+      tags.put = sinon.stub();
       var id = '1';
       var data = {
         name: 'Test'
       };
       tags.update(id, data);
-      assert(this.put.calledWithExactly('/tags/1', data));
+      assert(tags.put.calledWithExactly('/tags/1', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tags = new Tags(dispatcher);
+      tags.put = sinon.stub();
       var id = 'foobar';
       var data = {
         name: 'Test'
       };
       tags.update(id, data);
-      assert(this.put.calledWithExactly('/tags/NaN', data));
+      assert(tags.put.calledWithExactly('/tags/NaN', data));
     });
   });
 });

--- a/test/resources/tags_spec.js
+++ b/test/resources/tags_spec.js
@@ -69,7 +69,7 @@ describe('Tags', function() {
       var tags = new Tags(dispatcher);
       tags.getCollection = sinon.stub();
       tags.findAll();
-      assert(tags.get.calledWithExactly('/tags', undefined));
+      assert(tags.getCollection.calledWithExactly('/tags', undefined));
     });
 
     it('should handle with params', function() {
@@ -80,7 +80,7 @@ describe('Tags', function() {
         'opt_fields': 'id,name'
       };
       tags.findAll(params);
-      assert(tags.get.calledWithExactly('/tags', params));
+      assert(tags.getCollection.calledWithExactly('/tags', params));
     });
   });
 

--- a/test/resources/tags_spec.js
+++ b/test/resources/tags_spec.js
@@ -14,138 +14,116 @@ describe('Tags', function() {
 
   describe('#create', function() {
     it('should handle the creation', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tags = new Tags(dispatcher);
       var data = {
         name: 'Test'
       };
       tags.create(data);
-      assert(dispatcher.post.calledWithExactly('/tags', data));
+      assert(this.post.calledWithExactly('/tags', data));
     });
   });
 
   describe('#createInWorkspace', function() {
     it('should handle the creation', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tags = new Tags(dispatcher);
       var id = 1;
       var data = {
         name: 'Test'
       };
       tags.createInWorkspace(id, data);
-      assert(dispatcher.post.calledWithExactly('/workspaces/1/tags', data));
+      assert(this.post.calledWithExactly('/workspaces/1/tags', data));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tags = new Tags(dispatcher);
       var id = '1';
       var data = {
         name: 'Test'
       };
       tags.createInWorkspace(id, data);
-      assert(dispatcher.post.calledWithExactly('/workspaces/1/tags', data));
+      assert(this.post.calledWithExactly('/workspaces/1/tags', data));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tags = new Tags(dispatcher);
       var id = 'foobar';
       var data = {
         name: 'Test'
       };
       tags.createInWorkspace(id, data);
-      assert(dispatcher.post.calledWithExactly('/workspaces/NaN/tags', data));
+      assert(this.post.calledWithExactly('/workspaces/NaN/tags', data));
     });
   });
 
   describe('#findAll', function() {
     it('should handle without params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tags = new Tags(dispatcher);
       tags.findAll();
-      assert(dispatcher.get.calledWithExactly('/tags', undefined));
+      assert(this.get.calledWithExactly('/tags', undefined));
     });
 
     it('should handle with params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tags = new Tags(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       tags.findAll(params);
-      assert(dispatcher.get.calledWithExactly('/tags', params));
+      assert(this.get.calledWithExactly('/tags', params));
     });
   });
 
   describe('#findById', function() {
     it('should handle without params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tags = new Tags(dispatcher);
       var id = 1;
       tags.findById(id);
-      assert(dispatcher.get.calledWithExactly('/tags/1', undefined));
+      assert(this.get.calledWithExactly('/tags/1', undefined));
     });
 
     it('should handle with params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tags = new Tags(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       tags.findById(id, params);
-      assert(dispatcher.get.calledWithExactly('/tags/1', params));
+      assert(this.get.calledWithExactly('/tags/1', params));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tags = new Tags(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       tags.findById(id, params);
-      assert(dispatcher.get.calledWithExactly('/tags/1', params));
+      assert(this.get.calledWithExactly('/tags/1', params));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tags = new Tags(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       tags.findById(id, params);
-      assert(dispatcher.get.calledWithExactly('/tags/NaN', params));
+      assert(this.get.calledWithExactly('/tags/NaN', params));
     });
   });
 
   describe('#findByWorkspace', function() {
     it('should handle without params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tags = new Tags(dispatcher);
       var id = 1;
       tags.findByWorkspace(id);
@@ -154,83 +132,71 @@ describe('Tags', function() {
     });
 
     it('should handle with params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tags = new Tags(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       tags.findByWorkspace(id, params);
-      assert(dispatcher.get.calledWithExactly('/workspaces/1/tags', params));
+      assert(this.get.calledWithExactly('/workspaces/1/tags', params));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tags = new Tags(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       tags.findByWorkspace(id, params);
-      assert(dispatcher.get.calledWithExactly('/workspaces/1/tags', params));
+      assert(this.get.calledWithExactly('/workspaces/1/tags', params));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tags = new Tags(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       tags.findByWorkspace(id, params);
-      assert(dispatcher.get.calledWithExactly('/workspaces/NaN/tags', params));
+      assert(this.get.calledWithExactly('/workspaces/NaN/tags', params));
     });
   });
 
   describe('#update', function() {
     it('should handle the update', function() {
-      var dispatcher = {
-        put: sinon.stub()
-      };
+      var dispatcher = {};
       var tags = new Tags(dispatcher);
       var id = 1;
       var data = {
         name: 'Test'
       };
       tags.update(id, data);
-      assert(dispatcher.put.calledWithExactly('/tags/1', data));
+      assert(this.put.calledWithExactly('/tags/1', data));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        put: sinon.stub()
-      };
+      var dispatcher = {};
       var tags = new Tags(dispatcher);
       var id = '1';
       var data = {
         name: 'Test'
       };
       tags.update(id, data);
-      assert(dispatcher.put.calledWithExactly('/tags/1', data));
+      assert(this.put.calledWithExactly('/tags/1', data));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        put: sinon.stub()
-      };
+      var dispatcher = {};
       var tags = new Tags(dispatcher);
       var id = 'foobar';
       var data = {
         name: 'Test'
       };
       tags.update(id, data);
-      assert(dispatcher.put.calledWithExactly('/tags/NaN', data));
+      assert(this.put.calledWithExactly('/tags/NaN', data));
     });
   });
 });

--- a/test/resources/tasks_spec.js
+++ b/test/resources/tasks_spec.js
@@ -16,11 +16,12 @@ describe('Tasks', function() {
     it('should handle the creation', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var data = {
         name: 'Test'
       };
       tasks.create(data);
-      assert(this.post.calledWithExactly('/tasks', data));
+      assert(tasks.post.calledWithExactly('/tasks', data));
     });
   });
 
@@ -28,35 +29,38 @@ describe('Tasks', function() {
     it('should handle the creation', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = 1;
       var data = {
         name: 'Test'
       };
       tasks.createInWorkspace(id, data);
-      assert(this.post.calledWithExactly('/workspaces/1/tasks', data));
+      assert(tasks.post.calledWithExactly('/workspaces/1/tasks', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = '1';
       var data = {
         name: 'Test'
       };
       tasks.createInWorkspace(id, data);
-      assert(this.post.calledWithExactly('/workspaces/1/tasks', data));
+      assert(tasks.post.calledWithExactly('/workspaces/1/tasks', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = 'foobar';
       var data = {
         name: 'Test'
       };
       tasks.createInWorkspace(id, data);
       assert(
-        dispatcher.post.calledWithExactly('/workspaces/NaN/tasks', data));
+        tasks.post.calledWithExactly('/workspaces/NaN/tasks', data));
     });
   });
 
@@ -64,18 +68,20 @@ describe('Tasks', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.getCollection = sinon.stub();
       tasks.findAll();
-      assert(this.get.calledWithExactly('/tasks', undefined));
+      assert(tasks.getCollection.calledWithExactly('/tasks', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       tasks.findAll(params);
-      assert(this.get.calledWithExactly('/tasks', params));
+      assert(tasks.getCollection.calledWithExactly('/tasks', params));
     });
   });
 
@@ -83,42 +89,46 @@ describe('Tasks', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.get = sinon.stub();
       var id = 1;
       tasks.findById(id);
-      assert(this.get.calledWithExactly('/tasks/1', undefined));
+      assert(tasks.get.calledWithExactly('/tasks/1', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.get = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       tasks.findById(id, params);
-      assert(this.get.calledWithExactly('/tasks/1', params));
+      assert(tasks.get.calledWithExactly('/tasks/1', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.get = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       tasks.findById(id, params);
-      assert(this.get.calledWithExactly('/tasks/1', params));
+      assert(tasks.get.calledWithExactly('/tasks/1', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.get = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       tasks.findById(id, params);
-      assert(this.get.calledWithExactly('/tasks/NaN', params));
+      assert(tasks.get.calledWithExactly('/tasks/NaN', params));
     });
   });
 
@@ -126,46 +136,50 @@ describe('Tasks', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.getCollection = sinon.stub();
       var id = 1;
       tasks.findByProject(id);
       assert(
-        dispatcher.get.calledWithExactly('/projects/1/tasks', undefined));
+        tasks.getCollection.calledWithExactly('/projects/1/tasks', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       tasks.findByProject(id, params);
       assert(
-        dispatcher.get.calledWithExactly('/projects/1/tasks', params));
+        tasks.getCollection.calledWithExactly('/projects/1/tasks', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       tasks.findByProject(id, params);
       assert(
-        dispatcher.get.calledWithExactly('/projects/1/tasks', params));
+        tasks.getCollection.calledWithExactly('/projects/1/tasks', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       tasks.findByProject(id, params);
       assert(
-        dispatcher.get.calledWithExactly('/projects/NaN/tasks', params));
+        tasks.getCollection.calledWithExactly('/projects/NaN/tasks', params));
     });
   });
 
@@ -173,46 +187,50 @@ describe('Tasks', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.getCollection = sinon.stub();
       var id = 1;
       tasks.findByTag(id);
       assert(
-        dispatcher.get.calledWithExactly('/tags/1/tasks', undefined));
+        tasks.getCollection.calledWithExactly('/tags/1/tasks', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       tasks.findByTag(id, params);
       assert(
-        dispatcher.get.calledWithExactly('/tags/1/tasks', params));
+        tasks.getCollection.calledWithExactly('/tags/1/tasks', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       tasks.findByTag(id, params);
       assert(
-        dispatcher.get.calledWithExactly('/tags/1/tasks', params));
+        tasks.getCollection.calledWithExactly('/tags/1/tasks', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       tasks.findByTag(id, params);
       assert(
-        dispatcher.get.calledWithExactly('/tags/NaN/tasks', params));
+        tasks.getCollection.calledWithExactly('/tags/NaN/tasks', params));
     });
   });
 
@@ -220,60 +238,66 @@ describe('Tasks', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.put = sinon.stub();
       var id = 1;
       var data = {
         name: 'Test'
       };
       tasks.update(id, data);
-      assert(this.put.calledWithExactly('/tasks/1', data));
+      assert(tasks.put.calledWithExactly('/tasks/1', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.put = sinon.stub();
       var id = '1';
       var data = {
         name: 'Test'
       };
       tasks.update(id, data);
-      assert(this.put.calledWithExactly('/tasks/1', data));
+      assert(tasks.put.calledWithExactly('/tasks/1', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.put = sinon.stub();
       var id = 'foobar';
       var data = {
         name: 'Test'
       };
       tasks.update(id, data);
-      assert(this.put.calledWithExactly('/tasks/NaN', data));
+      assert(tasks.put.calledWithExactly('/tasks/NaN', data));
     });
   });
 
-  describe('#delete', function() {
+  describe('#destroy', function() {
     it('should handle the deletion', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.delete = sinon.stub();
       var id = 1;
-      tasks.delete(id);
-      assert(this.delete.calledWithExactly('/tasks/1'));
+      tasks.destroy(id);
+      assert(tasks.delete.calledWithExactly('/tasks/1'));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.delete = sinon.stub();
       var id = '1';
-      tasks.delete(id);
-      assert(this.delete.calledWithExactly('/tasks/1'));
+      tasks.destroy(id);
+      assert(tasks.delete.calledWithExactly('/tasks/1'));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.delete = sinon.stub();
       var id = 'foobar';
-      tasks.delete(id);
-      assert(this.delete.calledWithExactly('/tasks/NaN'));
+      tasks.destroy(id);
+      assert(tasks.delete.calledWithExactly('/tasks/NaN'));
     });
   });
 
@@ -281,35 +305,38 @@ describe('Tasks', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = 1;
       var data = {
         followers: [1]
       };
       tasks.addFollowers(id, data);
-      assert(this.post.calledWithExactly('/tasks/1/addFollowers', data));
+      assert(tasks.post.calledWithExactly('/tasks/1/addFollowers', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = '1';
       var data = {
         followers: [1]
       };
       tasks.addFollowers(id, data);
-      assert(this.post.calledWithExactly('/tasks/1/addFollowers', data));
+      assert(tasks.post.calledWithExactly('/tasks/1/addFollowers', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = 'foobar';
       var data = {
         followers: [1]
       };
       tasks.addFollowers(id, data);
       assert(
-        dispatcher.post.calledWithExactly('/tasks/NaN/addFollowers', data));
+        tasks.post.calledWithExactly('/tasks/NaN/addFollowers', data));
     });
   });
 
@@ -317,37 +344,40 @@ describe('Tasks', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = 1;
       var data = {
         followers: [1]
       };
       tasks.removeFollowers(id, data);
       assert(
-        dispatcher.post.calledWithExactly('/tasks/1/removeFollowers', data));
+        tasks.post.calledWithExactly('/tasks/1/removeFollowers', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = '1';
       var data = {
         followers: [1]
       };
       tasks.removeFollowers(id, data);
       assert(
-        dispatcher.post.calledWithExactly('/tasks/1/removeFollowers', data));
+        tasks.post.calledWithExactly('/tasks/1/removeFollowers', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = 'foobar';
       var data = {
         followers: [1]
       };
       tasks.removeFollowers(id, data);
       assert(
-        dispatcher.post.calledWithExactly('/tasks/NaN/removeFollowers', data));
+        tasks.post.calledWithExactly('/tasks/NaN/removeFollowers', data));
     });
   });
 
@@ -355,26 +385,32 @@ describe('Tasks', function() {
     it('should handle the request', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.getCollection = sinon.stub();
       var id = 1;
       tasks.projects(id);
-      assert(this.get.calledWith('/tasks/1/projects', undefined));
+      assert(tasks.getCollection.calledWith('/tasks/1/projects', undefined));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.getCollection = sinon.stub();
       var id = '1';
       tasks.projects(id);
-      assert(this.get.calledWithExactly('/tasks/1/projects', undefined));
+      assert(
+          tasks.getCollection.calledWithExactly(
+              '/tasks/1/projects', undefined));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.getCollection = sinon.stub();
       var id = 'foobar';
       tasks.projects(id);
       assert(
-        dispatcher.get.calledWithExactly('/tasks/NaN/projects', undefined));
+        tasks.getCollection.calledWithExactly(
+            '/tasks/NaN/projects', undefined));
     });
   });
 
@@ -382,35 +418,38 @@ describe('Tasks', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = 1;
       var data = {
         project: [1]
       };
       tasks.addProject(id, data);
-      assert(this.post.calledWithExactly('/tasks/1/addProject', data));
+      assert(tasks.post.calledWithExactly('/tasks/1/addProject', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = '1';
       var data = {
         project: [1]
       };
       tasks.addProject(id, data);
-      assert(this.post.calledWithExactly('/tasks/1/addProject', data));
+      assert(tasks.post.calledWithExactly('/tasks/1/addProject', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = 'foobar';
       var data = {
         project: [1]
       };
       tasks.addProject(id, data);
       assert(
-        dispatcher.post.calledWithExactly('/tasks/NaN/addProject', data));
+        tasks.post.calledWithExactly('/tasks/NaN/addProject', data));
     });
   });
 
@@ -418,35 +457,38 @@ describe('Tasks', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = 1;
       var data = {
         project: [1]
       };
       tasks.removeProject(id, data);
-      assert(this.post.calledWithExactly('/tasks/1/removeProject', data));
+      assert(tasks.post.calledWithExactly('/tasks/1/removeProject', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = '1';
       var data = {
         project: [1]
       };
       tasks.removeProject(id, data);
-      assert(this.post.calledWithExactly('/tasks/1/removeProject', data));
+      assert(tasks.post.calledWithExactly('/tasks/1/removeProject', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = 'foobar';
       var data = {
         project: [1]
       };
       tasks.removeProject(id, data);
       assert(
-        dispatcher.post.calledWithExactly('/tasks/NaN/removeProject', data));
+        tasks.post.calledWithExactly('/tasks/NaN/removeProject', data));
     });
   });
 
@@ -454,26 +496,29 @@ describe('Tasks', function() {
     it('should handle the request', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.getCollection = sinon.stub();
       var id = 1;
       tasks.tags(id);
-      assert(this.get.calledWith('/tasks/1/tags', undefined));
+      assert(tasks.getCollection.calledWith('/tasks/1/tags', undefined));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.getCollection = sinon.stub();
       var id = '1';
       tasks.tags(id);
-      assert(this.get.calledWithExactly('/tasks/1/tags', undefined));
+      assert(tasks.getCollection.calledWithExactly('/tasks/1/tags', undefined));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.getCollection = sinon.stub();
       var id = 'foobar';
       tasks.tags(id);
       assert(
-        dispatcher.get.calledWithExactly('/tasks/NaN/tags', undefined));
+        tasks.getCollection.calledWithExactly('/tasks/NaN/tags', undefined));
     });
   });
 
@@ -481,35 +526,38 @@ describe('Tasks', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = 1;
       var data = {
         tag: 1
       };
       tasks.addTag(id, data);
-      assert(this.post.calledWithExactly('/tasks/1/addTag', data));
+      assert(tasks.post.calledWithExactly('/tasks/1/addTag', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = '1';
       var data = {
         tag: 1
       };
       tasks.addTag(id, data);
-      assert(this.post.calledWithExactly('/tasks/1/addTag', data));
+      assert(tasks.post.calledWithExactly('/tasks/1/addTag', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = 'foobar';
       var data = {
         tag: 1
       };
       tasks.addTag(id, data);
       assert(
-        dispatcher.post.calledWithExactly('/tasks/NaN/addTag', data));
+        tasks.post.calledWithExactly('/tasks/NaN/addTag', data));
     });
   });
 
@@ -517,35 +565,38 @@ describe('Tasks', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = 1;
       var data = {
         tag: 1
       };
       tasks.removeTag(id, data);
-      assert(this.post.calledWithExactly('/tasks/1/removeTag', data));
+      assert(tasks.post.calledWithExactly('/tasks/1/removeTag', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = '1';
       var data = {
         tag: 1
       };
       tasks.removeTag(id, data);
-      assert(this.post.calledWithExactly('/tasks/1/removeTag', data));
+      assert(tasks.post.calledWithExactly('/tasks/1/removeTag', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = 'foobar';
       var data = {
         tag: 1
       };
       tasks.removeTag(id, data);
       assert(
-        dispatcher.post.calledWithExactly('/tasks/NaN/removeTag', data));
+        tasks.post.calledWithExactly('/tasks/NaN/removeTag', data));
     });
   });
 
@@ -553,26 +604,31 @@ describe('Tasks', function() {
     it('should handle the request', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.getCollection = sinon.stub();
       var id = 1;
       tasks.subtasks(id);
-      assert(this.get.calledWith('/tasks/1/subtasks', undefined));
+      assert(tasks.getCollection.calledWith('/tasks/1/subtasks', undefined));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.getCollection = sinon.stub();
       var id = '1';
       tasks.subtasks(id);
-      assert(this.get.calledWithExactly('/tasks/1/subtasks', undefined));
+      assert(tasks.getCollection.calledWithExactly(
+          '/tasks/1/subtasks', undefined));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.getCollection = sinon.stub();
       var id = 'foobar';
       tasks.subtasks(id);
       assert(
-        dispatcher.get.calledWithExactly('/tasks/NaN/subtasks', undefined));
+        tasks.getCollection.calledWithExactly(
+            '/tasks/NaN/subtasks', undefined));
     });
   });
 
@@ -580,30 +636,33 @@ describe('Tasks', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = 1;
       var data = {
         name: 'foo',
         assignee: 1234
       };
       tasks.addSubtask(id, data);
-      assert(this.post.calledWithExactly('/tasks/1/subtasks', data));
+      assert(tasks.post.calledWithExactly('/tasks/1/subtasks', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = '1';
       var data = {
         name: 'foo',
         assignee: 1234
       };
       tasks.addSubtask(id, data);
-      assert(this.post.calledWithExactly('/tasks/1/subtasks', data));
+      assert(tasks.post.calledWithExactly('/tasks/1/subtasks', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = 'foobar';
       var data = {
         name: 'foo',
@@ -611,7 +670,7 @@ describe('Tasks', function() {
       };
       tasks.addSubtask(id, data);
       assert(
-        dispatcher.post.calledWithExactly('/tasks/NaN/subtasks', data));
+        tasks.post.calledWithExactly('/tasks/NaN/subtasks', data));
     });
   });
 
@@ -619,30 +678,33 @@ describe('Tasks', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = 1;
       var parentId = 2;
       var data = {
         parent: parentId
       };
       tasks.setParent(id, parentId);
-      assert(this.post.calledWithExactly('/tasks/1/setParent', data));
+      assert(tasks.post.calledWithExactly('/tasks/1/setParent', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = '1';
       var parentId = '2';
       var data = {
         parent: 2
       };
       tasks.setParent(id, parentId);
-      assert(this.post.calledWithExactly('/tasks/1/setParent', data));
+      assert(tasks.post.calledWithExactly('/tasks/1/setParent', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
+      tasks.post = sinon.stub();
       var id = 'foobar';
       var parentId = 'fizzbuzz';
       var data = {
@@ -650,7 +712,7 @@ describe('Tasks', function() {
       };
       tasks.setParent(id, parentId);
       assert(
-        dispatcher.post.calledWithExactly('/tasks/NaN/setParent', data));
+        tasks.post.calledWithExactly('/tasks/NaN/setParent', data));
     });
   });
 });

--- a/test/resources/tasks_spec.js
+++ b/test/resources/tasks_spec.js
@@ -16,12 +16,12 @@ describe('Tasks', function() {
     it('should handle the creation', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var data = {
         name: 'Test'
       };
       tasks.create(data);
-      assert(tasks.post.calledWithExactly('/tasks', data));
+      assert(tasks.dispatchPost.calledWithExactly('/tasks', data));
     });
   });
 
@@ -29,38 +29,38 @@ describe('Tasks', function() {
     it('should handle the creation', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = 1;
       var data = {
         name: 'Test'
       };
       tasks.createInWorkspace(id, data);
-      assert(tasks.post.calledWithExactly('/workspaces/1/tasks', data));
+      assert(tasks.dispatchPost.calledWithExactly('/workspaces/1/tasks', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = '1';
       var data = {
         name: 'Test'
       };
       tasks.createInWorkspace(id, data);
-      assert(tasks.post.calledWithExactly('/workspaces/1/tasks', data));
+      assert(tasks.dispatchPost.calledWithExactly('/workspaces/1/tasks', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = 'foobar';
       var data = {
         name: 'Test'
       };
       tasks.createInWorkspace(id, data);
       assert(
-        tasks.post.calledWithExactly('/workspaces/NaN/tasks', data));
+        tasks.dispatchPost.calledWithExactly('/workspaces/NaN/tasks', data));
     });
   });
 
@@ -68,20 +68,21 @@ describe('Tasks', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.getCollection = sinon.stub();
+      tasks.dispatchGetCollection = sinon.stub();
       tasks.findAll();
-      assert(tasks.getCollection.calledWithExactly('/tasks', undefined));
+      assert(
+          tasks.dispatchGetCollection.calledWithExactly('/tasks', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.getCollection = sinon.stub();
+      tasks.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       tasks.findAll(params);
-      assert(tasks.getCollection.calledWithExactly('/tasks', params));
+      assert(tasks.dispatchGetCollection.calledWithExactly('/tasks', params));
     });
   });
 
@@ -89,46 +90,46 @@ describe('Tasks', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.get = sinon.stub();
+      tasks.dispatchGet = sinon.stub();
       var id = 1;
       tasks.findById(id);
-      assert(tasks.get.calledWithExactly('/tasks/1', undefined));
+      assert(tasks.dispatchGet.calledWithExactly('/tasks/1', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.get = sinon.stub();
+      tasks.dispatchGet = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       tasks.findById(id, params);
-      assert(tasks.get.calledWithExactly('/tasks/1', params));
+      assert(tasks.dispatchGet.calledWithExactly('/tasks/1', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.get = sinon.stub();
+      tasks.dispatchGet = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       tasks.findById(id, params);
-      assert(tasks.get.calledWithExactly('/tasks/1', params));
+      assert(tasks.dispatchGet.calledWithExactly('/tasks/1', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.get = sinon.stub();
+      tasks.dispatchGet = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       tasks.findById(id, params);
-      assert(tasks.get.calledWithExactly('/tasks/NaN', params));
+      assert(tasks.dispatchGet.calledWithExactly('/tasks/NaN', params));
     });
   });
 
@@ -136,50 +137,54 @@ describe('Tasks', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.getCollection = sinon.stub();
+      tasks.dispatchGetCollection = sinon.stub();
       var id = 1;
       tasks.findByProject(id);
       assert(
-        tasks.getCollection.calledWithExactly('/projects/1/tasks', undefined));
+          tasks.dispatchGetCollection.calledWithExactly(
+              '/projects/1/tasks', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.getCollection = sinon.stub();
+      tasks.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       tasks.findByProject(id, params);
       assert(
-        tasks.getCollection.calledWithExactly('/projects/1/tasks', params));
+          tasks.dispatchGetCollection.calledWithExactly(
+              '/projects/1/tasks', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.getCollection = sinon.stub();
+      tasks.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       tasks.findByProject(id, params);
       assert(
-        tasks.getCollection.calledWithExactly('/projects/1/tasks', params));
+          tasks.dispatchGetCollection.calledWithExactly(
+              '/projects/1/tasks', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.getCollection = sinon.stub();
+      tasks.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       tasks.findByProject(id, params);
       assert(
-        tasks.getCollection.calledWithExactly('/projects/NaN/tasks', params));
+          tasks.dispatchGetCollection.calledWithExactly(
+              '/projects/NaN/tasks', params));
     });
   });
 
@@ -187,50 +192,52 @@ describe('Tasks', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.getCollection = sinon.stub();
+      tasks.dispatchGetCollection = sinon.stub();
       var id = 1;
       tasks.findByTag(id);
       assert(
-        tasks.getCollection.calledWithExactly('/tags/1/tasks', undefined));
+          tasks.dispatchGetCollection.calledWithExactly(
+              '/tags/1/tasks', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.getCollection = sinon.stub();
+      tasks.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       tasks.findByTag(id, params);
       assert(
-        tasks.getCollection.calledWithExactly('/tags/1/tasks', params));
+        tasks.dispatchGetCollection.calledWithExactly('/tags/1/tasks', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.getCollection = sinon.stub();
+      tasks.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       tasks.findByTag(id, params);
       assert(
-        tasks.getCollection.calledWithExactly('/tags/1/tasks', params));
+        tasks.dispatchGetCollection.calledWithExactly('/tags/1/tasks', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.getCollection = sinon.stub();
+      tasks.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       tasks.findByTag(id, params);
       assert(
-        tasks.getCollection.calledWithExactly('/tags/NaN/tasks', params));
+          tasks.dispatchGetCollection.calledWithExactly(
+              '/tags/NaN/tasks', params));
     });
   });
 
@@ -238,66 +245,66 @@ describe('Tasks', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.put = sinon.stub();
+      tasks.dispatchPut = sinon.stub();
       var id = 1;
       var data = {
         name: 'Test'
       };
       tasks.update(id, data);
-      assert(tasks.put.calledWithExactly('/tasks/1', data));
+      assert(tasks.dispatchPut.calledWithExactly('/tasks/1', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.put = sinon.stub();
+      tasks.dispatchPut = sinon.stub();
       var id = '1';
       var data = {
         name: 'Test'
       };
       tasks.update(id, data);
-      assert(tasks.put.calledWithExactly('/tasks/1', data));
+      assert(tasks.dispatchPut.calledWithExactly('/tasks/1', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.put = sinon.stub();
+      tasks.dispatchPut = sinon.stub();
       var id = 'foobar';
       var data = {
         name: 'Test'
       };
       tasks.update(id, data);
-      assert(tasks.put.calledWithExactly('/tasks/NaN', data));
+      assert(tasks.dispatchPut.calledWithExactly('/tasks/NaN', data));
     });
   });
 
-  describe('#destroy', function() {
+  describe('#delete', function() {
     it('should handle the deletion', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.delete = sinon.stub();
+      tasks.dispatchDelete = sinon.stub();
       var id = 1;
-      tasks.destroy(id);
-      assert(tasks.delete.calledWithExactly('/tasks/1'));
+      tasks.delete(id);
+      assert(tasks.dispatchDelete.calledWithExactly('/tasks/1'));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.delete = sinon.stub();
+      tasks.dispatchDelete = sinon.stub();
       var id = '1';
-      tasks.destroy(id);
-      assert(tasks.delete.calledWithExactly('/tasks/1'));
+      tasks.delete(id);
+      assert(tasks.dispatchDelete.calledWithExactly('/tasks/1'));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.delete = sinon.stub();
+      tasks.dispatchDelete = sinon.stub();
       var id = 'foobar';
-      tasks.destroy(id);
-      assert(tasks.delete.calledWithExactly('/tasks/NaN'));
+      tasks.delete(id);
+      assert(tasks.dispatchDelete.calledWithExactly('/tasks/NaN'));
     });
   });
 
@@ -305,38 +312,40 @@ describe('Tasks', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = 1;
       var data = {
         followers: [1]
       };
       tasks.addFollowers(id, data);
-      assert(tasks.post.calledWithExactly('/tasks/1/addFollowers', data));
+      assert(
+          tasks.dispatchPost.calledWithExactly('/tasks/1/addFollowers', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = '1';
       var data = {
         followers: [1]
       };
       tasks.addFollowers(id, data);
-      assert(tasks.post.calledWithExactly('/tasks/1/addFollowers', data));
+      assert(
+          tasks.dispatchPost.calledWithExactly('/tasks/1/addFollowers', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = 'foobar';
       var data = {
         followers: [1]
       };
       tasks.addFollowers(id, data);
       assert(
-        tasks.post.calledWithExactly('/tasks/NaN/addFollowers', data));
+        tasks.dispatchPost.calledWithExactly('/tasks/NaN/addFollowers', data));
     });
   });
 
@@ -344,40 +353,41 @@ describe('Tasks', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = 1;
       var data = {
         followers: [1]
       };
       tasks.removeFollowers(id, data);
       assert(
-        tasks.post.calledWithExactly('/tasks/1/removeFollowers', data));
+        tasks.dispatchPost.calledWithExactly('/tasks/1/removeFollowers', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = '1';
       var data = {
         followers: [1]
       };
       tasks.removeFollowers(id, data);
       assert(
-        tasks.post.calledWithExactly('/tasks/1/removeFollowers', data));
+        tasks.dispatchPost.calledWithExactly('/tasks/1/removeFollowers', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = 'foobar';
       var data = {
         followers: [1]
       };
       tasks.removeFollowers(id, data);
       assert(
-        tasks.post.calledWithExactly('/tasks/NaN/removeFollowers', data));
+          tasks.dispatchPost.calledWithExactly(
+              '/tasks/NaN/removeFollowers', data));
     });
   });
 
@@ -385,31 +395,33 @@ describe('Tasks', function() {
     it('should handle the request', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.getCollection = sinon.stub();
+      tasks.dispatchGetCollection = sinon.stub();
       var id = 1;
       tasks.projects(id);
-      assert(tasks.getCollection.calledWith('/tasks/1/projects', undefined));
+      assert(
+          tasks.dispatchGetCollection.calledWith(
+              '/tasks/1/projects', undefined));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.getCollection = sinon.stub();
+      tasks.dispatchGetCollection = sinon.stub();
       var id = '1';
       tasks.projects(id);
       assert(
-          tasks.getCollection.calledWithExactly(
+          tasks.dispatchGetCollection.calledWithExactly(
               '/tasks/1/projects', undefined));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.getCollection = sinon.stub();
+      tasks.dispatchGetCollection = sinon.stub();
       var id = 'foobar';
       tasks.projects(id);
       assert(
-        tasks.getCollection.calledWithExactly(
+        tasks.dispatchGetCollection.calledWithExactly(
             '/tasks/NaN/projects', undefined));
     });
   });
@@ -418,38 +430,38 @@ describe('Tasks', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = 1;
       var data = {
         project: [1]
       };
       tasks.addProject(id, data);
-      assert(tasks.post.calledWithExactly('/tasks/1/addProject', data));
+      assert(tasks.dispatchPost.calledWithExactly('/tasks/1/addProject', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = '1';
       var data = {
         project: [1]
       };
       tasks.addProject(id, data);
-      assert(tasks.post.calledWithExactly('/tasks/1/addProject', data));
+      assert(tasks.dispatchPost.calledWithExactly('/tasks/1/addProject', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = 'foobar';
       var data = {
         project: [1]
       };
       tasks.addProject(id, data);
       assert(
-        tasks.post.calledWithExactly('/tasks/NaN/addProject', data));
+        tasks.dispatchPost.calledWithExactly('/tasks/NaN/addProject', data));
     });
   });
 
@@ -457,38 +469,41 @@ describe('Tasks', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = 1;
       var data = {
         project: [1]
       };
       tasks.removeProject(id, data);
-      assert(tasks.post.calledWithExactly('/tasks/1/removeProject', data));
+      assert(
+          tasks.dispatchPost.calledWithExactly('/tasks/1/removeProject', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = '1';
       var data = {
         project: [1]
       };
       tasks.removeProject(id, data);
-      assert(tasks.post.calledWithExactly('/tasks/1/removeProject', data));
+      assert(
+          tasks.dispatchPost.calledWithExactly('/tasks/1/removeProject', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = 'foobar';
       var data = {
         project: [1]
       };
       tasks.removeProject(id, data);
       assert(
-        tasks.post.calledWithExactly('/tasks/NaN/removeProject', data));
+          tasks.dispatchPost.calledWithExactly(
+              '/tasks/NaN/removeProject', data));
     });
   });
 
@@ -496,29 +511,33 @@ describe('Tasks', function() {
     it('should handle the request', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.getCollection = sinon.stub();
+      tasks.dispatchGetCollection = sinon.stub();
       var id = 1;
       tasks.tags(id);
-      assert(tasks.getCollection.calledWith('/tasks/1/tags', undefined));
+      assert(
+          tasks.dispatchGetCollection.calledWith('/tasks/1/tags', undefined));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.getCollection = sinon.stub();
+      tasks.dispatchGetCollection = sinon.stub();
       var id = '1';
       tasks.tags(id);
-      assert(tasks.getCollection.calledWithExactly('/tasks/1/tags', undefined));
+      assert(
+          tasks.dispatchGetCollection.calledWithExactly(
+              '/tasks/1/tags', undefined));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.getCollection = sinon.stub();
+      tasks.dispatchGetCollection = sinon.stub();
       var id = 'foobar';
       tasks.tags(id);
       assert(
-        tasks.getCollection.calledWithExactly('/tasks/NaN/tags', undefined));
+          tasks.dispatchGetCollection.calledWithExactly(
+              '/tasks/NaN/tags', undefined));
     });
   });
 
@@ -526,38 +545,38 @@ describe('Tasks', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = 1;
       var data = {
         tag: 1
       };
       tasks.addTag(id, data);
-      assert(tasks.post.calledWithExactly('/tasks/1/addTag', data));
+      assert(tasks.dispatchPost.calledWithExactly('/tasks/1/addTag', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = '1';
       var data = {
         tag: 1
       };
       tasks.addTag(id, data);
-      assert(tasks.post.calledWithExactly('/tasks/1/addTag', data));
+      assert(tasks.dispatchPost.calledWithExactly('/tasks/1/addTag', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = 'foobar';
       var data = {
         tag: 1
       };
       tasks.addTag(id, data);
       assert(
-        tasks.post.calledWithExactly('/tasks/NaN/addTag', data));
+        tasks.dispatchPost.calledWithExactly('/tasks/NaN/addTag', data));
     });
   });
 
@@ -565,38 +584,38 @@ describe('Tasks', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = 1;
       var data = {
         tag: 1
       };
       tasks.removeTag(id, data);
-      assert(tasks.post.calledWithExactly('/tasks/1/removeTag', data));
+      assert(tasks.dispatchPost.calledWithExactly('/tasks/1/removeTag', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = '1';
       var data = {
         tag: 1
       };
       tasks.removeTag(id, data);
-      assert(tasks.post.calledWithExactly('/tasks/1/removeTag', data));
+      assert(tasks.dispatchPost.calledWithExactly('/tasks/1/removeTag', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = 'foobar';
       var data = {
         tag: 1
       };
       tasks.removeTag(id, data);
       assert(
-        tasks.post.calledWithExactly('/tasks/NaN/removeTag', data));
+        tasks.dispatchPost.calledWithExactly('/tasks/NaN/removeTag', data));
     });
   });
 
@@ -604,30 +623,32 @@ describe('Tasks', function() {
     it('should handle the request', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.getCollection = sinon.stub();
+      tasks.dispatchGetCollection = sinon.stub();
       var id = 1;
       tasks.subtasks(id);
-      assert(tasks.getCollection.calledWith('/tasks/1/subtasks', undefined));
+      assert(
+          tasks.dispatchGetCollection.calledWith(
+              '/tasks/1/subtasks', undefined));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.getCollection = sinon.stub();
+      tasks.dispatchGetCollection = sinon.stub();
       var id = '1';
       tasks.subtasks(id);
-      assert(tasks.getCollection.calledWithExactly(
+      assert(tasks.dispatchGetCollection.calledWithExactly(
           '/tasks/1/subtasks', undefined));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.getCollection = sinon.stub();
+      tasks.dispatchGetCollection = sinon.stub();
       var id = 'foobar';
       tasks.subtasks(id);
       assert(
-        tasks.getCollection.calledWithExactly(
+        tasks.dispatchGetCollection.calledWithExactly(
             '/tasks/NaN/subtasks', undefined));
     });
   });
@@ -636,33 +657,33 @@ describe('Tasks', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = 1;
       var data = {
         name: 'foo',
         assignee: 1234
       };
       tasks.addSubtask(id, data);
-      assert(tasks.post.calledWithExactly('/tasks/1/subtasks', data));
+      assert(tasks.dispatchPost.calledWithExactly('/tasks/1/subtasks', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = '1';
       var data = {
         name: 'foo',
         assignee: 1234
       };
       tasks.addSubtask(id, data);
-      assert(tasks.post.calledWithExactly('/tasks/1/subtasks', data));
+      assert(tasks.dispatchPost.calledWithExactly('/tasks/1/subtasks', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = 'foobar';
       var data = {
         name: 'foo',
@@ -670,7 +691,7 @@ describe('Tasks', function() {
       };
       tasks.addSubtask(id, data);
       assert(
-        tasks.post.calledWithExactly('/tasks/NaN/subtasks', data));
+        tasks.dispatchPost.calledWithExactly('/tasks/NaN/subtasks', data));
     });
   });
 
@@ -678,33 +699,33 @@ describe('Tasks', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = 1;
       var parentId = 2;
       var data = {
         parent: parentId
       };
       tasks.setParent(id, parentId);
-      assert(tasks.post.calledWithExactly('/tasks/1/setParent', data));
+      assert(tasks.dispatchPost.calledWithExactly('/tasks/1/setParent', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = '1';
       var parentId = '2';
       var data = {
         parent: 2
       };
       tasks.setParent(id, parentId);
-      assert(tasks.post.calledWithExactly('/tasks/1/setParent', data));
+      assert(tasks.dispatchPost.calledWithExactly('/tasks/1/setParent', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var tasks = new Tasks(dispatcher);
-      tasks.post = sinon.stub();
+      tasks.dispatchPost = sinon.stub();
       var id = 'foobar';
       var parentId = 'fizzbuzz';
       var data = {
@@ -712,7 +733,7 @@ describe('Tasks', function() {
       };
       tasks.setParent(id, parentId);
       assert(
-        tasks.post.calledWithExactly('/tasks/NaN/setParent', data));
+        tasks.dispatchPost.calledWithExactly('/tasks/NaN/setParent', data));
     });
   });
 });

--- a/test/resources/tasks_spec.js
+++ b/test/resources/tasks_spec.js
@@ -14,49 +14,41 @@ describe('Tasks', function() {
 
   describe('#create', function() {
     it('should handle the creation', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var data = {
         name: 'Test'
       };
       tasks.create(data);
-      assert(dispatcher.post.calledWithExactly('/tasks', data));
+      assert(this.post.calledWithExactly('/tasks', data));
     });
   });
 
   describe('#createInWorkspace', function() {
     it('should handle the creation', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 1;
       var data = {
         name: 'Test'
       };
       tasks.createInWorkspace(id, data);
-      assert(dispatcher.post.calledWithExactly('/workspaces/1/tasks', data));
+      assert(this.post.calledWithExactly('/workspaces/1/tasks', data));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = '1';
       var data = {
         name: 'Test'
       };
       tasks.createInWorkspace(id, data);
-      assert(dispatcher.post.calledWithExactly('/workspaces/1/tasks', data));
+      assert(this.post.calledWithExactly('/workspaces/1/tasks', data));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 'foobar';
       var data = {
@@ -70,83 +62,69 @@ describe('Tasks', function() {
 
   describe('#findAll', function() {
     it('should handle without params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       tasks.findAll();
-      assert(dispatcher.get.calledWithExactly('/tasks', undefined));
+      assert(this.get.calledWithExactly('/tasks', undefined));
     });
 
     it('should handle with params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       tasks.findAll(params);
-      assert(dispatcher.get.calledWithExactly('/tasks', params));
+      assert(this.get.calledWithExactly('/tasks', params));
     });
   });
 
   describe('#findById', function() {
     it('should handle without params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 1;
       tasks.findById(id);
-      assert(dispatcher.get.calledWithExactly('/tasks/1', undefined));
+      assert(this.get.calledWithExactly('/tasks/1', undefined));
     });
 
     it('should handle with params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       tasks.findById(id, params);
-      assert(dispatcher.get.calledWithExactly('/tasks/1', params));
+      assert(this.get.calledWithExactly('/tasks/1', params));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       tasks.findById(id, params);
-      assert(dispatcher.get.calledWithExactly('/tasks/1', params));
+      assert(this.get.calledWithExactly('/tasks/1', params));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       tasks.findById(id, params);
-      assert(dispatcher.get.calledWithExactly('/tasks/NaN', params));
+      assert(this.get.calledWithExactly('/tasks/NaN', params));
     });
   });
 
   describe('#findByProject', function() {
     it('should handle without params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 1;
       tasks.findByProject(id);
@@ -155,9 +133,7 @@ describe('Tasks', function() {
     });
 
     it('should handle with params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var params = {
         'opt_fields': 'id,name'
@@ -169,9 +145,7 @@ describe('Tasks', function() {
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var params = {
         'opt_fields': 'id,name'
@@ -183,9 +157,7 @@ describe('Tasks', function() {
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var params = {
         'opt_fields': 'id,name'
@@ -199,9 +171,7 @@ describe('Tasks', function() {
 
   describe('#findByTag', function() {
     it('should handle without params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 1;
       tasks.findByTag(id);
@@ -210,9 +180,7 @@ describe('Tasks', function() {
     });
 
     it('should handle with params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var params = {
         'opt_fields': 'id,name'
@@ -224,9 +192,7 @@ describe('Tasks', function() {
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var params = {
         'opt_fields': 'id,name'
@@ -238,9 +204,7 @@ describe('Tasks', function() {
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var params = {
         'opt_fields': 'id,name'
@@ -254,108 +218,90 @@ describe('Tasks', function() {
 
   describe('#update', function() {
     it('should handle the update', function() {
-      var dispatcher = {
-        put: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 1;
       var data = {
         name: 'Test'
       };
       tasks.update(id, data);
-      assert(dispatcher.put.calledWithExactly('/tasks/1', data));
+      assert(this.put.calledWithExactly('/tasks/1', data));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        put: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = '1';
       var data = {
         name: 'Test'
       };
       tasks.update(id, data);
-      assert(dispatcher.put.calledWithExactly('/tasks/1', data));
+      assert(this.put.calledWithExactly('/tasks/1', data));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        put: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 'foobar';
       var data = {
         name: 'Test'
       };
       tasks.update(id, data);
-      assert(dispatcher.put.calledWithExactly('/tasks/NaN', data));
+      assert(this.put.calledWithExactly('/tasks/NaN', data));
     });
   });
 
   describe('#delete', function() {
     it('should handle the deletion', function() {
-      var dispatcher = {
-        delete: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 1;
       tasks.delete(id);
-      assert(dispatcher.delete.calledWithExactly('/tasks/1'));
+      assert(this.delete.calledWithExactly('/tasks/1'));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        delete: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = '1';
       tasks.delete(id);
-      assert(dispatcher.delete.calledWithExactly('/tasks/1'));
+      assert(this.delete.calledWithExactly('/tasks/1'));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        delete: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 'foobar';
       tasks.delete(id);
-      assert(dispatcher.delete.calledWithExactly('/tasks/NaN'));
+      assert(this.delete.calledWithExactly('/tasks/NaN'));
     });
   });
 
   describe('#addFollowers', function() {
     it('should handle the update', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 1;
       var data = {
         followers: [1]
       };
       tasks.addFollowers(id, data);
-      assert(dispatcher.post.calledWithExactly('/tasks/1/addFollowers', data));
+      assert(this.post.calledWithExactly('/tasks/1/addFollowers', data));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = '1';
       var data = {
         followers: [1]
       };
       tasks.addFollowers(id, data);
-      assert(dispatcher.post.calledWithExactly('/tasks/1/addFollowers', data));
+      assert(this.post.calledWithExactly('/tasks/1/addFollowers', data));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 'foobar';
       var data = {
@@ -369,9 +315,7 @@ describe('Tasks', function() {
 
   describe('#removeFollowers', function() {
     it('should handle the update', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 1;
       var data = {
@@ -383,9 +327,7 @@ describe('Tasks', function() {
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = '1';
       var data = {
@@ -397,9 +339,7 @@ describe('Tasks', function() {
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 'foobar';
       var data = {
@@ -413,29 +353,23 @@ describe('Tasks', function() {
 
   describe('#projects', function() {
     it('should handle the request', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 1;
       tasks.projects(id);
-      assert(dispatcher.get.calledWith('/tasks/1/projects', undefined));
+      assert(this.get.calledWith('/tasks/1/projects', undefined));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = '1';
       tasks.projects(id);
-      assert(dispatcher.get.calledWithExactly('/tasks/1/projects', undefined));
+      assert(this.get.calledWithExactly('/tasks/1/projects', undefined));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 'foobar';
       tasks.projects(id);
@@ -446,35 +380,29 @@ describe('Tasks', function() {
 
   describe('#addProject', function() {
     it('should handle the update', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 1;
       var data = {
         project: [1]
       };
       tasks.addProject(id, data);
-      assert(dispatcher.post.calledWithExactly('/tasks/1/addProject', data));
+      assert(this.post.calledWithExactly('/tasks/1/addProject', data));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = '1';
       var data = {
         project: [1]
       };
       tasks.addProject(id, data);
-      assert(dispatcher.post.calledWithExactly('/tasks/1/addProject', data));
+      assert(this.post.calledWithExactly('/tasks/1/addProject', data));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 'foobar';
       var data = {
@@ -488,35 +416,29 @@ describe('Tasks', function() {
 
   describe('#removeProject', function() {
     it('should handle the update', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 1;
       var data = {
         project: [1]
       };
       tasks.removeProject(id, data);
-      assert(dispatcher.post.calledWithExactly('/tasks/1/removeProject', data));
+      assert(this.post.calledWithExactly('/tasks/1/removeProject', data));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = '1';
       var data = {
         project: [1]
       };
       tasks.removeProject(id, data);
-      assert(dispatcher.post.calledWithExactly('/tasks/1/removeProject', data));
+      assert(this.post.calledWithExactly('/tasks/1/removeProject', data));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 'foobar';
       var data = {
@@ -530,29 +452,23 @@ describe('Tasks', function() {
 
   describe('#tags', function() {
     it('should handle the request', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 1;
       tasks.tags(id);
-      assert(dispatcher.get.calledWith('/tasks/1/tags', undefined));
+      assert(this.get.calledWith('/tasks/1/tags', undefined));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = '1';
       tasks.tags(id);
-      assert(dispatcher.get.calledWithExactly('/tasks/1/tags', undefined));
+      assert(this.get.calledWithExactly('/tasks/1/tags', undefined));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 'foobar';
       tasks.tags(id);
@@ -563,35 +479,29 @@ describe('Tasks', function() {
 
   describe('#addTag', function() {
     it('should handle the update', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 1;
       var data = {
         tag: 1
       };
       tasks.addTag(id, data);
-      assert(dispatcher.post.calledWithExactly('/tasks/1/addTag', data));
+      assert(this.post.calledWithExactly('/tasks/1/addTag', data));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = '1';
       var data = {
         tag: 1
       };
       tasks.addTag(id, data);
-      assert(dispatcher.post.calledWithExactly('/tasks/1/addTag', data));
+      assert(this.post.calledWithExactly('/tasks/1/addTag', data));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 'foobar';
       var data = {
@@ -605,35 +515,29 @@ describe('Tasks', function() {
 
   describe('#removeTag', function() {
     it('should handle the update', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 1;
       var data = {
         tag: 1
       };
       tasks.removeTag(id, data);
-      assert(dispatcher.post.calledWithExactly('/tasks/1/removeTag', data));
+      assert(this.post.calledWithExactly('/tasks/1/removeTag', data));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = '1';
       var data = {
         tag: 1
       };
       tasks.removeTag(id, data);
-      assert(dispatcher.post.calledWithExactly('/tasks/1/removeTag', data));
+      assert(this.post.calledWithExactly('/tasks/1/removeTag', data));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 'foobar';
       var data = {
@@ -647,29 +551,23 @@ describe('Tasks', function() {
 
   describe('#subtasks', function() {
     it('should handle the request', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 1;
       tasks.subtasks(id);
-      assert(dispatcher.get.calledWith('/tasks/1/subtasks', undefined));
+      assert(this.get.calledWith('/tasks/1/subtasks', undefined));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = '1';
       tasks.subtasks(id);
-      assert(dispatcher.get.calledWithExactly('/tasks/1/subtasks', undefined));
+      assert(this.get.calledWithExactly('/tasks/1/subtasks', undefined));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 'foobar';
       tasks.subtasks(id);
@@ -680,9 +578,7 @@ describe('Tasks', function() {
 
   describe('#addSubtask', function() {
     it('should handle the update', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 1;
       var data = {
@@ -690,13 +586,11 @@ describe('Tasks', function() {
         assignee: 1234
       };
       tasks.addSubtask(id, data);
-      assert(dispatcher.post.calledWithExactly('/tasks/1/subtasks', data));
+      assert(this.post.calledWithExactly('/tasks/1/subtasks', data));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = '1';
       var data = {
@@ -704,13 +598,11 @@ describe('Tasks', function() {
         assignee: 1234
       };
       tasks.addSubtask(id, data);
-      assert(dispatcher.post.calledWithExactly('/tasks/1/subtasks', data));
+      assert(this.post.calledWithExactly('/tasks/1/subtasks', data));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 'foobar';
       var data = {
@@ -725,9 +617,7 @@ describe('Tasks', function() {
 
   describe('#setParent', function() {
     it('should handle the update', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 1;
       var parentId = 2;
@@ -735,13 +625,11 @@ describe('Tasks', function() {
         parent: parentId
       };
       tasks.setParent(id, parentId);
-      assert(dispatcher.post.calledWithExactly('/tasks/1/setParent', data));
+      assert(this.post.calledWithExactly('/tasks/1/setParent', data));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = '1';
       var parentId = '2';
@@ -749,13 +637,11 @@ describe('Tasks', function() {
         parent: 2
       };
       tasks.setParent(id, parentId);
-      assert(dispatcher.post.calledWithExactly('/tasks/1/setParent', data));
+      assert(this.post.calledWithExactly('/tasks/1/setParent', data));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        post: sinon.stub()
-      };
+      var dispatcher = {};
       var tasks = new Tasks(dispatcher);
       var id = 'foobar';
       var parentId = 'fizzbuzz';

--- a/test/resources/teams_spec.js
+++ b/test/resources/teams_spec.js
@@ -16,53 +16,53 @@ describe('Teams', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var teams = new Teams(dispatcher);
-      teams.getCollection = sinon.stub();
+      teams.dispatchGetCollection = sinon.stub();
       var id = 1;
       teams.findByOrganization(id);
       assert(
-        teams.getCollection.calledWithExactly(
+        teams.dispatchGetCollection.calledWithExactly(
             '/organizations/1/teams', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var teams = new Teams(dispatcher);
-      teams.getCollection = sinon.stub();
+      teams.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       teams.findByOrganization(id, params);
       assert(
-        teams.getCollection.calledWithExactly(
+        teams.dispatchGetCollection.calledWithExactly(
             '/organizations/1/teams', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var teams = new Teams(dispatcher);
-      teams.getCollection = sinon.stub();
+      teams.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       teams.findByOrganization(id, params);
       assert(
-        teams.getCollection.calledWithExactly(
+        teams.dispatchGetCollection.calledWithExactly(
             '/organizations/1/teams', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var teams = new Teams(dispatcher);
-      teams.getCollection = sinon.stub();
+      teams.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       teams.findByOrganization(id, params);
       assert(
-        teams.getCollection.calledWithExactly(
+        teams.dispatchGetCollection.calledWithExactly(
             '/organizations/NaN/teams', params));
     });
   });

--- a/test/resources/teams_spec.js
+++ b/test/resources/teams_spec.js
@@ -14,56 +14,56 @@ describe('Teams', function() {
 
   describe('#findByOrganization', function() {
     it('should handle without params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var teams = new Teams(dispatcher);
+      teams.getCollection = sinon.stub();
       var id = 1;
       teams.findByOrganization(id);
       assert(
-        dispatcher.get.calledWithExactly('/organizations/1/teams', undefined));
+        teams.getCollection.calledWithExactly(
+            '/organizations/1/teams', undefined));
     });
 
     it('should handle with params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var teams = new Teams(dispatcher);
+      teams.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       teams.findByOrganization(id, params);
       assert(
-        dispatcher.get.calledWithExactly('/organizations/1/teams', params));
+        teams.getCollection.calledWithExactly(
+            '/organizations/1/teams', params));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var teams = new Teams(dispatcher);
+      teams.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       teams.findByOrganization(id, params);
       assert(
-        dispatcher.get.calledWithExactly('/organizations/1/teams', params));
+        teams.getCollection.calledWithExactly(
+            '/organizations/1/teams', params));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var teams = new Teams(dispatcher);
+      teams.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       teams.findByOrganization(id, params);
       assert(
-        dispatcher.get.calledWithExactly('/organizations/NaN/teams', params));
+        teams.getCollection.calledWithExactly(
+            '/organizations/NaN/teams', params));
     });
   });
 });

--- a/test/resources/users_spec.js
+++ b/test/resources/users_spec.js
@@ -16,9 +16,10 @@ describe('Users', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var users = new Users(dispatcher);
-      users.getCollection = sinon.stub();
+      users.dispatchGetCollection = sinon.stub();
       users.findAll();
-      assert(users.getCollection.calledWithExactly('/users', undefined));
+      assert(
+          users.dispatchGetCollection.calledWithExactly('/users', undefined));
     });
 
     it('should handle with params', function() {
@@ -27,9 +28,9 @@ describe('Users', function() {
       var params = {
         'opt_fields': 'id,name'
       };
-      users.getCollection = sinon.stub();
+      users.dispatchGetCollection = sinon.stub();
       users.findAll(params);
-      assert(users.getCollection.calledWithExactly('/users', params));
+      assert(users.dispatchGetCollection.calledWithExactly('/users', params));
     });
   });
 
@@ -37,20 +38,20 @@ describe('Users', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var users = new Users(dispatcher);
-      users.get = sinon.stub();
+      users.dispatchGet = sinon.stub();
       users.me();
-      assert(users.get.calledWithExactly('/users/me', undefined));
+      assert(users.dispatchGet.calledWithExactly('/users/me', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var users = new Users(dispatcher);
-      users.get = sinon.stub();
+      users.dispatchGet = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       users.me(params);
-      assert(users.get.calledWithExactly('/users/me', params));
+      assert(users.dispatchGet.calledWithExactly('/users/me', params));
     });
   });
 
@@ -58,46 +59,46 @@ describe('Users', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var users = new Users(dispatcher);
-      users.get = sinon.stub();
+      users.dispatchGet = sinon.stub();
       var id = 1;
       users.findById(id);
-      assert(users.get.calledWithExactly('/users/1', undefined));
+      assert(users.dispatchGet.calledWithExactly('/users/1', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var users = new Users(dispatcher);
-      users.get = sinon.stub();
+      users.dispatchGet = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       users.findById(id, params);
-      assert(users.get.calledWithExactly('/users/1', params));
+      assert(users.dispatchGet.calledWithExactly('/users/1', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var users = new Users(dispatcher);
-      users.get = sinon.stub();
+      users.dispatchGet = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       users.findById(id, params);
-      assert(users.get.calledWithExactly('/users/1', params));
+      assert(users.dispatchGet.calledWithExactly('/users/1', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var users = new Users(dispatcher);
-      users.get = sinon.stub();
+      users.dispatchGet = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       users.findById(id, params);
-      assert(users.get.calledWithExactly('/users/NaN', params));
+      assert(users.dispatchGet.calledWithExactly('/users/NaN', params));
     });
   });
 
@@ -105,50 +106,50 @@ describe('Users', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var users = new Users(dispatcher);
-      users.getCollection = sinon.stub();
+      users.dispatchGetCollection = sinon.stub();
       var id = 1;
       users.findByWorkspace(id);
       assert(
-        users.getCollection.calledWithExactly(
+        users.dispatchGetCollection.calledWithExactly(
             '/workspaces/1/users', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var users = new Users(dispatcher);
-      users.getCollection = sinon.stub();
+      users.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       users.findByWorkspace(id, params);
-      assert(users.getCollection.calledWithExactly(
+      assert(users.dispatchGetCollection.calledWithExactly(
           '/workspaces/1/users', params));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var users = new Users(dispatcher);
-      users.getCollection = sinon.stub();
+      users.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       users.findByWorkspace(id, params);
-      assert(users.getCollection.calledWithExactly(
+      assert(users.dispatchGetCollection.calledWithExactly(
           '/workspaces/1/users', params));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var users = new Users(dispatcher);
-      users.getCollection = sinon.stub();
+      users.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       users.findByWorkspace(id, params);
-      assert(users.getCollection.calledWithExactly(
+      assert(users.dispatchGetCollection.calledWithExactly(
           '/workspaces/NaN/users', params));
     });
   });

--- a/test/resources/users_spec.js
+++ b/test/resources/users_spec.js
@@ -14,150 +14,142 @@ describe('Users', function() {
 
   describe('#findAll', function() {
     it('should handle without params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var users = new Users(dispatcher);
+      users.getCollection = sinon.stub();
       users.findAll();
-      assert(dispatcher.get.calledWithExactly('/users', undefined));
+      assert(users.getCollection.calledWithExactly('/users', undefined));
     });
 
     it('should handle with params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var users = new Users(dispatcher);
       var params = {
         'opt_fields': 'id,name'
       };
+      users.getCollection = sinon.stub();
       users.findAll(params);
-      assert(dispatcher.get.calledWithExactly('/users', params));
+      assert(users.getCollection.calledWithExactly('/users', params));
     });
   });
 
   describe('#me', function() {
     it('should handle without params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var users = new Users(dispatcher);
+      users.get = sinon.stub();
       users.me();
-      assert(dispatcher.get.calledWithExactly('/users/me', undefined));
+      assert(users.get.calledWithExactly('/users/me', undefined));
     });
 
     it('should handle with params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var users = new Users(dispatcher);
+      users.get = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       users.me(params);
-      assert(dispatcher.get.calledWithExactly('/users/me', params));
+      assert(users.get.calledWithExactly('/users/me', params));
     });
   });
 
   describe('#findById', function() {
     it('should handle without params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var users = new Users(dispatcher);
+      users.get = sinon.stub();
       var id = 1;
       users.findById(id);
-      assert(dispatcher.get.calledWithExactly('/users/1', undefined));
+      assert(users.get.calledWithExactly('/users/1', undefined));
     });
 
     it('should handle with params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var users = new Users(dispatcher);
+      users.get = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       users.findById(id, params);
-      assert(dispatcher.get.calledWithExactly('/users/1', params));
+      assert(users.get.calledWithExactly('/users/1', params));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var users = new Users(dispatcher);
+      users.get = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       users.findById(id, params);
-      assert(dispatcher.get.calledWithExactly('/users/1', params));
+      assert(users.get.calledWithExactly('/users/1', params));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var users = new Users(dispatcher);
+      users.get = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       users.findById(id, params);
-      assert(dispatcher.get.calledWithExactly('/users/NaN', params));
+      assert(users.get.calledWithExactly('/users/NaN', params));
     });
   });
 
   describe('#findByWorkspace', function() {
     it('should handle without params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var users = new Users(dispatcher);
+      users.getCollection = sinon.stub();
       var id = 1;
       users.findByWorkspace(id);
       assert(
-        dispatcher.get.calledWithExactly('/workspaces/1/users', undefined));
+        users.getCollection.calledWithExactly(
+            '/workspaces/1/users', undefined));
     });
 
     it('should handle with params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var users = new Users(dispatcher);
+      users.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 1;
       users.findByWorkspace(id, params);
-      assert(dispatcher.get.calledWithExactly('/workspaces/1/users', params));
+      assert(users.getCollection.calledWithExactly(
+          '/workspaces/1/users', params));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var users = new Users(dispatcher);
+      users.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = '1';
       users.findByWorkspace(id, params);
-      assert(dispatcher.get.calledWithExactly('/workspaces/1/users', params));
+      assert(users.getCollection.calledWithExactly(
+          '/workspaces/1/users', params));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var users = new Users(dispatcher);
+      users.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       var id = 'foobar';
       users.findByWorkspace(id, params);
-      assert(dispatcher.get.calledWithExactly('/workspaces/NaN/users', params));
+      assert(users.getCollection.calledWithExactly(
+          '/workspaces/NaN/users', params));
     });
   });
 });

--- a/test/resources/workspaces_spec.js
+++ b/test/resources/workspaces_spec.js
@@ -113,11 +113,12 @@ describe('Workspaces', function() {
       var id = 'baz';
       var data = {
         type: 'task',
-        query: 'foobar'
+        query: 'foobar',
+        limit: 50
       };
       workspaces.typeahead(id, data);
       assert(dispatcher.get.calledWithExactly(
-        '/workspaces/NaN/typeahead', data));
+        '/workspaces/NaN/typeahead', data, undefined));
     });
   });
 });

--- a/test/resources/workspaces_spec.js
+++ b/test/resources/workspaces_spec.js
@@ -14,111 +14,103 @@ describe('Workspaces', function() {
 
   describe('#findAll', function() {
     it('should handle without params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var workspaces = new Workspaces(dispatcher);
+      workspaces.getCollection = sinon.stub();
       workspaces.findAll();
-      assert(dispatcher.get.calledWithExactly('/workspaces', undefined));
+      assert(workspaces.getCollection.calledWithExactly(
+          '/workspaces', undefined));
     });
 
     it('should handle with params', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var workspaces = new Workspaces(dispatcher);
+      workspaces.getCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       workspaces.findAll(params);
-      assert(dispatcher.get.calledWithExactly('/workspaces', params));
+      assert(workspaces.getCollection.calledWithExactly('/workspaces', params));
     });
   });
 
   describe('#update', function() {
     it('should handle the update', function() {
-      var dispatcher = {
-        put: sinon.stub()
-      };
+      var dispatcher = {};
       var workspaces = new Workspaces(dispatcher);
+      workspaces.put = sinon.stub();
       var id = 1;
       var data = {
         name: 'Test'
       };
       workspaces.update(id, data);
-      assert(dispatcher.put.calledWithExactly('/workspaces/1', data));
+      assert(workspaces.put.calledWithExactly('/workspaces/1', data));
     });
 
     it('should handle string numbers', function() {
-      var dispatcher = {
-        put: sinon.stub()
-      };
+      var dispatcher = {};
       var workspaces = new Workspaces(dispatcher);
+      workspaces.put = sinon.stub();
       var id = '1';
       var data = {
         name: 'Test'
       };
       workspaces.update(id, data);
-      assert(dispatcher.put.calledWithExactly('/workspaces/1', data));
+      assert(workspaces.put.calledWithExactly('/workspaces/1', data));
     });
 
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        put: sinon.stub()
-      };
+      var dispatcher = {};
       var workspaces = new Workspaces(dispatcher);
+      workspaces.put = sinon.stub();
       var id = 'foobar';
       var data = {
         name: 'Test'
       };
       workspaces.update(id, data);
-      assert(dispatcher.put.calledWithExactly('/workspaces/NaN', data));
+      assert(workspaces.put.calledWithExactly('/workspaces/NaN', data));
     });
   });
 
   describe('#typeahead', function() {
     it('should handle task typeahead', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var workspaces = new Workspaces(dispatcher);
+      workspaces.getCollection = sinon.stub();
       var id = 1;
       var data = {
         type: 'task',
         query: 'foobar'
       };
       workspaces.typeahead(id, data);
-      assert(dispatcher.get.calledWithExactly(
+      assert(workspaces.getCollection.calledWithExactly(
         '/workspaces/1/typeahead', data));
     });
     it('should handle string numbers in typeahead', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var workspaces = new Workspaces(dispatcher);
+      workspaces.getCollection = sinon.stub();
       var id = '1';
       var data = {
         type: 'task',
         query: 'foobar'
       };
       workspaces.typeahead(id, data);
-      assert(dispatcher.get.calledWithExactly(
+      assert(workspaces.getCollection.calledWithExactly(
         '/workspaces/1/typeahead', data));
     });
     it('should do weird things with real strings', function() {
-      var dispatcher = {
-        get: sinon.stub()
-      };
+      var dispatcher = {};
       var workspaces = new Workspaces(dispatcher);
+      workspaces.getCollection = sinon.stub();
       var id = 'baz';
       var data = {
         type: 'task',
-        query: 'foobar',
-        limit: 50
+        query: 'foobar'
       };
       workspaces.typeahead(id, data);
-      assert(dispatcher.get.calledWithExactly(
-        '/workspaces/NaN/typeahead', data, undefined));
+      assert(workspaces.getCollection.calledWithExactly(
+        '/workspaces/NaN/typeahead', data));
     });
   });
 });

--- a/test/resources/workspaces_spec.js
+++ b/test/resources/workspaces_spec.js
@@ -16,21 +16,23 @@ describe('Workspaces', function() {
     it('should handle without params', function() {
       var dispatcher = {};
       var workspaces = new Workspaces(dispatcher);
-      workspaces.getCollection = sinon.stub();
+      workspaces.dispatchGetCollection = sinon.stub();
       workspaces.findAll();
-      assert(workspaces.getCollection.calledWithExactly(
+      assert(workspaces.dispatchGetCollection.calledWithExactly(
           '/workspaces', undefined));
     });
 
     it('should handle with params', function() {
       var dispatcher = {};
       var workspaces = new Workspaces(dispatcher);
-      workspaces.getCollection = sinon.stub();
+      workspaces.dispatchGetCollection = sinon.stub();
       var params = {
         'opt_fields': 'id,name'
       };
       workspaces.findAll(params);
-      assert(workspaces.getCollection.calledWithExactly('/workspaces', params));
+      assert(
+          workspaces.dispatchGetCollection.calledWithExactly(
+              '/workspaces', params));
     });
   });
 
@@ -38,37 +40,37 @@ describe('Workspaces', function() {
     it('should handle the update', function() {
       var dispatcher = {};
       var workspaces = new Workspaces(dispatcher);
-      workspaces.put = sinon.stub();
+      workspaces.dispatchPut = sinon.stub();
       var id = 1;
       var data = {
         name: 'Test'
       };
       workspaces.update(id, data);
-      assert(workspaces.put.calledWithExactly('/workspaces/1', data));
+      assert(workspaces.dispatchPut.calledWithExactly('/workspaces/1', data));
     });
 
     it('should handle string numbers', function() {
       var dispatcher = {};
       var workspaces = new Workspaces(dispatcher);
-      workspaces.put = sinon.stub();
+      workspaces.dispatchPut = sinon.stub();
       var id = '1';
       var data = {
         name: 'Test'
       };
       workspaces.update(id, data);
-      assert(workspaces.put.calledWithExactly('/workspaces/1', data));
+      assert(workspaces.dispatchPut.calledWithExactly('/workspaces/1', data));
     });
 
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var workspaces = new Workspaces(dispatcher);
-      workspaces.put = sinon.stub();
+      workspaces.dispatchPut = sinon.stub();
       var id = 'foobar';
       var data = {
         name: 'Test'
       };
       workspaces.update(id, data);
-      assert(workspaces.put.calledWithExactly('/workspaces/NaN', data));
+      assert(workspaces.dispatchPut.calledWithExactly('/workspaces/NaN', data));
     });
   });
 
@@ -76,40 +78,40 @@ describe('Workspaces', function() {
     it('should handle task typeahead', function() {
       var dispatcher = {};
       var workspaces = new Workspaces(dispatcher);
-      workspaces.getCollection = sinon.stub();
+      workspaces.dispatchGetCollection = sinon.stub();
       var id = 1;
       var data = {
         type: 'task',
         query: 'foobar'
       };
       workspaces.typeahead(id, data);
-      assert(workspaces.getCollection.calledWithExactly(
+      assert(workspaces.dispatchGetCollection.calledWithExactly(
         '/workspaces/1/typeahead', data));
     });
     it('should handle string numbers in typeahead', function() {
       var dispatcher = {};
       var workspaces = new Workspaces(dispatcher);
-      workspaces.getCollection = sinon.stub();
+      workspaces.dispatchGetCollection = sinon.stub();
       var id = '1';
       var data = {
         type: 'task',
         query: 'foobar'
       };
       workspaces.typeahead(id, data);
-      assert(workspaces.getCollection.calledWithExactly(
+      assert(workspaces.dispatchGetCollection.calledWithExactly(
         '/workspaces/1/typeahead', data));
     });
     it('should do weird things with real strings', function() {
       var dispatcher = {};
       var workspaces = new Workspaces(dispatcher);
-      workspaces.getCollection = sinon.stub();
+      workspaces.dispatchGetCollection = sinon.stub();
       var id = 'baz';
       var data = {
         type: 'task',
         query: 'foobar'
       };
       workspaces.typeahead(id, data);
-      assert(workspaces.getCollection.calledWithExactly(
+      assert(workspaces.dispatchGetCollection.calledWithExactly(
         '/workspaces/NaN/typeahead', data));
     });
   });


### PR DESCRIPTION
Resource members now return either the full payload (for collections) with pagination info, or unwrap if the response is just a single resource.

The Dispatcher now always returns the full payload, and single-resource calls automatically unwrap the `data` member. Collection-based calls always return the full response so the client can request further pages.

Version bump to 0.5.0