### PR TITLE
(doc) Specify Object for tasks.add*

### DIFF
--- a/lib/resources/tasks.js
+++ b/lib/resources/tasks.js
@@ -151,7 +151,7 @@ Tasks.prototype.projects = function(taskId) {
  * Dispatches a POST request to /tasks/:taskId/addProject with the project to
  * add to to the task.
  * @param {Number} taskId The task id
- * @param {Number} data   The data containing the projectId
+ * @param {Object} data   The data containing the projectId
  * @return {Promise}      The result of the API call
  */
 Tasks.prototype.addProject = function(taskId, data) {
@@ -184,7 +184,7 @@ Tasks.prototype.tags = function(taskId) {
 /**
  * Add a tag to a task
  * @param {Number} taskId The task id
- * @param {Number} data   The data containing the tagId
+ * @param {Object} data   The data containing the tagId
  * @return {Promise}      The result of the API call
  */
 Tasks.prototype.addTag = function(taskId, data) {


### PR DESCRIPTION
These wrapper functions call out to `dispatchPost(path, data)` the passed data object, so they should be specified as `Object`s.

They had been specified as `Number`s. This corrects that.