### PR TITLE
allow for creation of a project within a team with new createInTeam function

### DIFF
--- a/lib/resources/projects.js
+++ b/lib/resources/projects.js
@@ -35,6 +35,18 @@ Projects.prototype.createInWorkspace = function(workspaceId, data) {
 };
 
 /**
+ * Dispatches a POST request to /teams/:teamId/projects of the API to
+ * create a new project within the team.
+ * @param  {Number} teamId The team id
+ * @param  {Object} data        The data for the project
+ * @return {Promise}            The result of the API call
+ */
+Projects.prototype.createInTeam = function(teamId, data) {
+  var path = util.format('/teams/%d/projects', teamId);
+  return this.dispatchPost(path, data);
+};
+
+/**
  * Dispatches a GET request to /projects/:projectId of the API to get
  * information about the project.
  * @param  {Number} projectId    The project id


### PR DESCRIPTION
create and createInWorkspace throw an error (requesting a workspace and a team respectively). Using teamIds successfully creates a project and so I added a simple function for posting to the teams/:teamId/projects endpoint patterned after the others in the projects module.