### PR TITLE
Fix streaming method

### DIFF
--- a/lib/util/resource_stream.js
+++ b/lib/util/resource_stream.js
@@ -54,7 +54,7 @@ ResourceStream.prototype._readUnbuffered = function() {
       me.pushBuffered(resource);
     });
     // Update promise to represent the next set of resources.
-    me.promise = paging.nextPage(me.dispatcher, response, me.dispatchOptions);
+    me.promise = paging.nextPage(response, me.dispatcher, me.dispatchOptions);
     me._fetching = false;
   }).catch(function(error) {
     // Failure - emit error.

--- a/lib/util/resource_stream.js
+++ b/lib/util/resource_stream.js
@@ -42,8 +42,7 @@ ResourceStream.prototype._readUnbuffered = function() {
   }
   me._fetching = true;
 
-  // When response comes back, we will push to stream.
-  me.promise.then(function(response) {
+  function updateStream(response) {
     if (!response.data || response.data.length === undefined ||
         response.next_page === undefined) {
       // We got a successful response back but it did not appear to contain
@@ -56,10 +55,21 @@ ResourceStream.prototype._readUnbuffered = function() {
     // Update promise to represent the next set of resources.
     me.promise = paging.nextPage(response, me.dispatcher, me.dispatchOptions);
     me._fetching = false;
-  }).catch(function(error) {
+
+    // a result set is waiting in the wings...
+    if (me.promise) {
+        me.promise.then(updateStream).catch(handleError);
+        me._fetching = true;
+    }
+  }
+
+  function handleError(error) {
     // Failure - emit error.
     me.emit('error', error);
-  });
+  }
+
+  // When response comes back, we will push to stream.
+  me.promise.then(updateStream).catch(handleError);
 };
 
 module.exports = ResourceStream;

--- a/test/util/resource_stream_spec.js
+++ b/test/util/resource_stream_spec.js
@@ -68,7 +68,7 @@ describe('ResourceStream', function() {
       assert.deepEqual(stream.pushBuffered.secondCall.args, ['second']);
       assert(nextPage.calledOnce);
       assert.deepEqual(
-          nextPage.firstCall.args, [dispatcher, response, undefined]);
+          nextPage.firstCall.args, [response, dispatcher, undefined]);
       assert.equal(stream.promise, nextPromise);
     });
 


### PR DESCRIPTION
I noticed that the stream doesn't work.

Essentially;

```javascript
var workspace_id = /** known workspace id **/;
client.authorize().then(function (client) {
    var stream = client.stream(client.projects.findByWorkspace(workspace_id));

    stream.on('data', function (data) {
        console.log(data);
    });
});
```

would cause:

```
Unhandled rejection Error: Cannot fetch next page of response that does not have paging info
    at Object.nextPage (/home/peterm/src/asana/node_modules/asana/lib/util/paging.js:27:11)
    at /home/peterm/src/asana/node_modules/asana/lib/util/resource_stream.js:57:25
    at tryCatcher (/home/peterm/src/asana/node_modules/asana/node_modules/bluebird/js/main/util.js:24:31)
    at Promise._settlePromiseFromHandler (/home/peterm/src/asana/node_modules/asana/node_modules/bluebird/js/main/promise.js:466:31)
    at Promise._settlePromiseAt (/home/peterm/src/asana/node_modules/asana/node_modules/bluebird/js/main/promise.js:545:18)
    at Promise._settlePromises (/home/peterm/src/asana/node_modules/asana/node_modules/bluebird/js/main/promise.js:661:14)
    at Async._drainQueue (/home/peterm/src/asana/node_modules/asana/node_modules/bluebird/js/main/async.js:79:16)
    at Async._drainQueues (/home/peterm/src/asana/node_modules/asana/node_modules/bluebird/js/main/async.js:89:10)
    at Async.drainQueues (/home/peterm/src/asana/node_modules/asana/node_modules/bluebird/js/main/async.js:14:14)
    at process._tickCallback (node.js:442:13)
```

The reason for this error is because the call to nextPage is wrong (arguments in the wrong order).

Fixing that revealed that the stream does not listen to the promise created by the call to next page. It just creates the promise but does not attach a then to it.

Thanks!
