### PR TITLE
Add support for auto refreshing oauth tokens

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "asana",
   "main": "dist/asana.js",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "homepage": "https://github.com/Asana/node-asana",
   "authors": [
     "Greg Slovacek <greg@asana.com>",

--- a/examples/oauth/browser/public/popup.html
+++ b/examples/oauth/browser/public/popup.html
@@ -43,7 +43,7 @@
         $('#ui').html('Hello ' + me.name + '!');
       });
     }).catch(function(err) {
-      $('#ui').html('Error: ' + err);
+      $('#ui').html('Error: ' + err.code + ': ' + err.description);
     });
   }
 

--- a/lib/auth/authenticator.js
+++ b/lib/auth/authenticator.js
@@ -17,14 +17,25 @@ Authenticator.prototype.authenticateRequest = function(request) {
 };
 
 /**
- * Establishes credentials. If credentials could be out of date and it is
- * possible to refresh them, does so.
+ * Establishes credentials.
  *
- * @return {Promise} Resolves when credentials have been successfully
- *     established and `authenticateRequest` calls can expect to succeed.
+ * @return {Promise} Resolves when initial credentials have been
+ *     completed and `authenticateRequest` calls can expect to succeed.
  */
-Authenticator.prototype.ensureCredentials = function() {
+Authenticator.prototype.establishCredentials = function() {
   throw new Error('not implemented');
 };
+
+/**
+ * Attempts to refresh credentials, if possible, given the current credentials.
+ *
+ * @return {Promise} Resolves to `true` if credentials have been successfully
+ *     established and `authenticateRequests` can expect to succeed, else
+ *     resolves to `false`.
+ */
+Authenticator.prototype.refreshCredentials = function() {
+  throw new Error('not implemented');
+};
+
 
 module.exports = Authenticator;

--- a/lib/auth/basic_authenticator.js
+++ b/lib/auth/basic_authenticator.js
@@ -20,8 +20,14 @@ BasicAuthenticator.prototype.authenticateRequest = function(request) {
   return request;
 };
 
-BasicAuthenticator.prototype.ensureCredentials = function() {
+BasicAuthenticator.prototype.establishCredentials = function() {
+  // Credentials are already built-in.
   return Bluebird.resolve();
+};
+
+BasicAuthenticator.prototype.refreshCredentials = function() {
+  // We have no way of refreshing credentials.
+  return Bluebird.resolve(false);
 };
 
 module.exports = BasicAuthenticator;

--- a/lib/auth/oauth_authenticator.js
+++ b/lib/auth/oauth_authenticator.js
@@ -7,6 +7,7 @@ var Authenticator = require('./authenticator');
  *
  * @param {Object} options Configure the authenticator; must specify one
  *     of `flow` or `credentials`.
+ * @option {App}           app           The app being authenticated for.
  * @option {OauthFlow}     [flow]        The flow to use to get credentials
  *     when needed.
  * @option {String|Object} [credentials] Initial credentials to use. This can
@@ -25,6 +26,7 @@ function OauthAuthenticator(options) {
     this.credentials = options.credentials || null;
   }
   this.flow = options.flow || null;
+  this.app = options.app;
 }
 
 util.inherits(OauthAuthenticator, Authenticator);
@@ -52,7 +54,8 @@ OauthAuthenticator.prototype.authenticateRequest = function(request) {
  * @return {Promise} Resolves when credentials have been successfully
  *     established and `authenticateRequests` can expect to succeed.
  */
-OauthAuthenticator.prototype.ensureCredentials = function() {
+OauthAuthenticator.prototype.establishCredentials = function() {
+  /* jshint camelcase: false */
   var me = this;
   if (me.flow) {
     // Request new credentials
@@ -61,9 +64,52 @@ OauthAuthenticator.prototype.ensureCredentials = function() {
       me.credentials = credentials;
     });
   } else {
-    // We were given a fixed set of credentials and don't know how to get
-    // new ones, so assume what we have is ok.
-    return Bluebird.resolve();
+    if (me.credentials.access_token) {
+      // Assume what we have is ok.
+      return Bluebird.resolve();
+    } else if (me.credentials.refresh_token) {
+      // We were given a refresh token but NOT an access token. Get access.
+      return me.refreshCredentials();
+    } else {
+      // What kind of credentials did we get anyway?
+      return Bluebird.reject(new Error('Invalid credentials'));
+    }
+  }
+};
+
+/**
+ * Attempts to refresh credentials, if possible, given the current credentials.
+ * @return {Promise} Resolves to `true` if credentials have been successfully
+ *     established and `authenticateRequests` can expect to succeed, else
+ *     resolves to `false`.
+ */
+OauthAuthenticator.prototype.refreshCredentials = function() {
+  /* jshint camelcase: false */
+  var me = this;
+  if (me.credentials && me.credentials.refresh_token) {
+    // We have a refresh token. Use it to get a new access token.
+    // Only have one outstanding request, any simultaneous requests waiting on
+    // refresh should gate on this promise.
+    if (!me.refreshPromise) {
+      var refreshToken = me.credentials.refresh_token;
+      me.refreshPromise = me.app.accessTokenFromRefreshToken(refreshToken).then(
+          function(credentials) {
+            // Update credentials, but hang on to refresh token.
+            if (!credentials.refresh_token) {
+              credentials.refresh_token = refreshToken;
+            }
+            me.credentials = credentials;
+            me.refreshPromise = null;
+            return true;
+          });
+    }
+    return me.refreshPromise;
+  } else if (me.flow) {
+    // Try running the flow again to get credentials.
+    return this.ensureCredentials();
+  } else {
+    // We are unable to refresh credentials automatically.
+    return Bluebird.resolve(false);
   }
 };
 

--- a/lib/auth/popup_flow.js
+++ b/lib/auth/popup_flow.js
@@ -43,9 +43,20 @@ PopupFlow.prototype.startAuthorization = function(authUrl, state) {
       }
     };
     window.addEventListener('message', listener, false);
-    window.open(authUrl, 'asana_oauth', me._popupParams(800, 600));
-    // TODO: listen for when window is closed so we don't hang forever if
-    // user closes popup or it is blocked?
+    var popup = window.open(authUrl, 'asana_oauth', me._popupParams(800, 600));
+
+    // Detect popup blocking and fail.
+    if (!popup || popup.outerHeight === 0) {
+      window.removeEventListener('message', listener, false);
+      reject(new Error('Popup blocked by browser'));
+    }
+
+    // Listen for when window is closed so we don't hang forever
+    var timer = setInterval(function() {
+      if (popup.closed) {
+        clearInterval(timer);
+      }
+    });
   });
   return Promise.resolve();
 };

--- a/lib/auth/popup_flow.js
+++ b/lib/auth/popup_flow.js
@@ -62,8 +62,8 @@ PopupFlow.prototype.startAuthorization = function(authUrl, state) {
     if (!popup) {
       cleanup();
       reject(new OauthError({
-        error: 'access_denied',
-        error_description: 'The popup window containing the ' +
+        'error': 'access_denied',
+        'error_description': 'The popup window containing the ' +
             'authorization UI was blocked by the browser.'
       }));
       return;
@@ -79,8 +79,8 @@ PopupFlow.prototype.startAuthorization = function(authUrl, state) {
         if (seenClosed) {
           cleanup();
           reject(new OauthError({
-            error: 'access_denied',
-            error_description: 'The popup window containing the ' +
+            'error': 'access_denied',
+            'error_description': 'The popup window containing the ' +
                 'authorization UI was closed by the user.'
           }));
         } else {

--- a/lib/auth/popup_flow.js
+++ b/lib/auth/popup_flow.js
@@ -20,8 +20,21 @@ util.inherits(PopupFlow, BaseBrowserFlow);
 
 PopupFlow.prototype.startAuthorization = function(authUrl, state) {
   var me = this;
+
+  var popup, popupTimer, listener;
+  function cleanup() {
+    if (popup && popupTimer) {
+      clearInterval(popupTimer);
+      popupTimer = null;
+    }
+    if (listener) {
+      window.removeEventListener('message', listener, false);
+      listener = null;
+    }
+  }
+
   me._authorizationPromise = new Bluebird(function(resolve, reject) {
-    var listener = function(event) {
+    listener = function(event) {
       var receivedUrl;
       try {
         receivedUrl = event.data.receivedUrl;
@@ -33,7 +46,7 @@ PopupFlow.prototype.startAuthorization = function(authUrl, state) {
         var params = oauthUtil.parseOauthResultFromUrl(receivedUrl);
         if (params.state === state) {
           state = null; // don't ever respond to again
-          window.removeEventListener('message', listener, false);
+          cleanup();
           if (params.error) {
             reject(new OauthError(params));
           } else {
@@ -43,18 +56,35 @@ PopupFlow.prototype.startAuthorization = function(authUrl, state) {
       }
     };
     window.addEventListener('message', listener, false);
-    var popup = window.open(authUrl, 'asana_oauth', me._popupParams(800, 600));
+    popup = window.open(authUrl, 'asana_oauth', me._popupParams(800, 600));
 
     // Detect popup blocking and fail.
     if (!popup || popup.outerHeight === 0) {
-      window.removeEventListener('message', listener, false);
-      reject(new Error('Popup blocked by browser'));
+      cleanup();
+      reject(new OauthError({
+        error: 'access_denied',
+        error_description: 'The popup window containing the ' +
+            'authorization UI was blocked by the browser.'
+      }));
     }
 
-    // Listen for when window is closed so we don't hang forever
-    var timer = setInterval(function() {
+    // Detect popup closure (which may not be handled by the content, because
+    // it may never load) and fail. If the popup posts a message to us, we
+    // SHOULD get that message before it closes and this interval fires,
+    // but just in case we wait for two successive intervals.
+    var seenClosed = false;
+    popupTimer = setInterval(function() {
       if (popup.closed) {
-        clearInterval(timer);
+        if (seenClosed) {
+          cleanup();
+          reject(new OauthError({
+            error: 'access_denied',
+            error_description: 'The popup window containing the ' +
+                'authorization UI was closed by the user.'
+          }));
+        } else {
+          seenClosed = true;
+        }
       }
     });
   });

--- a/lib/auth/popup_flow.js
+++ b/lib/auth/popup_flow.js
@@ -59,13 +59,14 @@ PopupFlow.prototype.startAuthorization = function(authUrl, state) {
     popup = window.open(authUrl, 'asana_oauth', me._popupParams(800, 600));
 
     // Detect popup blocking and fail.
-    if (!popup || popup.outerHeight === 0) {
+    if (!popup) {
       cleanup();
       reject(new OauthError({
         error: 'access_denied',
         error_description: 'The popup window containing the ' +
             'authorization UI was blocked by the browser.'
       }));
+      return;
     }
 
     // Detect popup closure (which may not be handled by the content, because

--- a/lib/auth/popup_flow.js
+++ b/lib/auth/popup_flow.js
@@ -86,7 +86,7 @@ PopupFlow.prototype.startAuthorization = function(authUrl, state) {
           seenClosed = true;
         }
       }
-    });
+    }, 500);
   });
   return Promise.resolve();
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -123,15 +123,20 @@ Client.prototype.useOauth = function(options) {
   options.app = this.app;
   var authenticator;
   if (options.credentials) {
-    authenticator =
-        new OauthAuthenticator({ credentials: options.credentials });
+    authenticator = new OauthAuthenticator({
+      app: this.app,
+      credentials: options.credentials
+    });
   } else {
     var FlowType = options.flowType || autoDetect();
     if (FlowType === null) {
       throw new Error('Could not autodetect Oauth flow type');
     }
     var flow = new FlowType(options);
-    authenticator = new OauthAuthenticator({ flow: flow });
+    authenticator = new OauthAuthenticator({
+      app: this.app,
+      flow: flow
+    });
   }
   this.dispatcher.setAuthenticator(authenticator);
   return this;

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -129,11 +129,14 @@ Dispatcher.prototype.dispatch = function(params, dispatchOptions) {
         }
         if (STATUS_MAP[res.statusCode]) {
           var error = new STATUS_MAP[res.statusCode](payload);
+
           if (me.retryOnRateLimit &&
               error instanceof (errors.RateLimitEnforced)) {
+            // Maybe attempt retry for rate limiting.
             // Delay a half-second more in case of rounding error.
             // TODO: verify Asana is always being conservative with duration
             setTimeout(doRequest, error.retryAfterSeconds * 1000 + 500);
+
           } else if (me.handleUnauthorized &&
               error instanceof (errors.NoAuthorization)) {
             // Maybe attempt to retry unauthorized requests after getting
@@ -145,7 +148,9 @@ Dispatcher.prototype.dispatch = function(params, dispatchOptions) {
                 reject(error);
               }
             });
+
           } else {
+            // Not an error we can handle.
             return reject(error);
           }
         } else {

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -115,6 +115,7 @@ Dispatcher.prototype.authorize = function() {
  */
 Dispatcher.prototype.dispatch = function(params, dispatchOptions) {
   var me = this;
+  // TODO: actually honor these options as overriding defaults
   dispatchOptions = dispatchOptions || {};
 
   return new Bluebird(function (resolve, reject) {

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -135,7 +135,8 @@ Dispatcher.prototype.dispatch = function(params, dispatchOptions) {
             setTimeout(doRequest, error.retryAfterSeconds * 1000 + 500);
           } else if (me.handleUnauthorized &&
               error instanceof (errors.NoAuthorization)) {
-            //
+            // Maybe attempt to retry unauthorized requests after getting
+            // a new access token.
             Bluebird.resolve(me.handleUnauthorized()).then(function(reauth) {
               if (reauth) {
                 doRequest();

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -23,6 +23,9 @@ var STATUS_MAP = Object.keys(errors).reduce(function(map, key) {
  *     Can also be set later with `setAuthenticator`.
  * @option {String} [retryOnRateLimit] Automatically handle `RateLimitEnforced`
  *     errors by sleeping and retrying after the waiting period.
+ * @option {Function} [handleUnauthorized] Automatically handle
+ *     `NoAuthorization` with the callback. If the callback returns `true`
+ *     (or a promise resolving to `true), will retry the request.
  * @option {String} [asanaBaseUrl] Base URL for Asana, for debugging
  */
 function Dispatcher(options) {
@@ -42,6 +45,14 @@ function Dispatcher(options) {
    * @type {Boolean}
    */
   this.retryOnRateLimit = options.retryOnRateLimit || false;
+  /**
+   * Handler for unauthorized requests which may seek reauthorization.
+   * Default behavior is available if configured with an Oauth authenticator
+   * that has a refresh token, and will refresh the current access token.
+   * @type {Function}
+   */
+  this.handleUnauthorized = (options.handleUnauthorized !== undefined) ?
+      options.handleUnauthorized : Dispatcher.maybeReauthorize;
 }
 
 /**
@@ -49,6 +60,19 @@ function Dispatcher(options) {
  * @type {String}
  */
 Dispatcher.API_PATH = 'api/1.0';
+
+/**
+ * Default handler for requests that are considered unauthorized.
+ * Requests that the authenticator try to refresh its credentials if
+ * possible.
+ * @return {Promise<boolean>} True iff refresh was successful, false if not.
+ */
+Dispatcher.maybeReauthorize = function() {
+  if (!this.authenticator) {
+    return false;
+  }
+  return this.authenticator.refreshCredentials();
+};
 
 /**
  * Creates an Asana API Url by concatenating the ROOT_URL with path provided.
@@ -79,7 +103,7 @@ Dispatcher.prototype.authorize = function() {
   if (this.authenticator === null) {
     throw new Error('No authenticator configured for dispatcher');
   }
-  return this.authenticator.ensureCredentials();
+  return this.authenticator.establishCredentials();
 };
 
 /**
@@ -93,12 +117,11 @@ Dispatcher.prototype.dispatch = function(params, dispatchOptions) {
   var me = this;
   dispatchOptions = dispatchOptions || {};
 
-  if (me.authenticator !== null) {
-    me.authenticator.authenticateRequest(params);
-  }
-
   return new Bluebird(function (resolve, reject) {
     function doRequest() {
+      if (me.authenticator !== null) {
+        me.authenticator.authenticateRequest(params);
+      }
       request(params, function(err, res, payload) {
         if (err) {
           return reject(err);
@@ -110,6 +133,16 @@ Dispatcher.prototype.dispatch = function(params, dispatchOptions) {
             // Delay a half-second more in case of rounding error.
             // TODO: verify Asana is always being conservative with duration
             setTimeout(doRequest, error.retryAfterSeconds * 1000 + 500);
+          } else if (me.handleUnauthorized &&
+              error instanceof (errors.NoAuthorization)) {
+            //
+            Bluebird.resolve(me.handleUnauthorized()).then(function(reauth) {
+              if (reauth) {
+                doRequest();
+              } else {
+                reject(error);
+              }
+            });
           } else {
             return reject(error);
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asana",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "A node.js client for the Asana API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Works when either the flow in use supports retrieving oauth tokens (e.g. `NativeFlow`) or if the `OauthAuthenticator` is configured with credentials that contain a `refresh_token`. The default behavior in that case on receiving a `401` is to make another token request to get a new access token. This should happen without any intervention / knowledge of the caller.

For flows that cannot use refresh tokens, we support running the flow again to re-obtain authorization (which often doesn't involve any actual user interaction).

We're still working on some automated tests for the auth stuff so in the meantime this was tested manually by:
* running the popup flow and blocking the popup, closing the popup, and using the popup normally
* running the native flows
* configuring the client with just a refresh token and observing it auto-request the access token.