### PR TITLE
Bugfixes for oauth reauthorization

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "asana",
   "main": "dist/asana.js",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "homepage": "https://github.com/Asana/node-asana",
   "authors": [
     "Greg Slovacek <greg@asana.com>",

--- a/lib/auth/oauth_authenticator.js
+++ b/lib/auth/oauth_authenticator.js
@@ -106,7 +106,9 @@ OauthAuthenticator.prototype.refreshCredentials = function() {
     return me.refreshPromise;
   } else if (me.flow) {
     // Try running the flow again to get credentials.
-    return this.ensureCredentials();
+    return this.establishCredentials().then(function(credentials) {
+      return credentials !== null;
+    });
   } else {
     // We are unable to refresh credentials automatically.
     return Bluebird.resolve(false);

--- a/lib/client.js
+++ b/lib/client.js
@@ -121,23 +121,19 @@ Client.prototype.useBasicAuth = function(apiKey) {
 Client.prototype.useOauth = function(options) {
   options = options || {};
   options.app = this.app;
-  var authenticator;
-  if (options.credentials) {
-    authenticator = new OauthAuthenticator({
-      app: this.app,
-      credentials: options.credentials
-    });
-  } else {
-    var FlowType = options.flowType || autoDetect();
-    if (FlowType === null) {
-      throw new Error('Could not autodetect Oauth flow type');
-    }
-    var flow = new FlowType(options);
-    authenticator = new OauthAuthenticator({
-      app: this.app,
-      flow: flow
-    });
+
+  var FlowType = options.flowType || autoDetect();
+  // If there are no credentials, then we can't proceed without a flow.
+  if (!options.credentials && FlowType === null) {
+    throw new Error('Could not autodetect Oauth flow type');
   }
+  var flow = new FlowType(options);
+  var authenticator = new OauthAuthenticator({
+    app: this.app,
+    credentials: options.credentials,
+    flow: flow
+  });
+
   this.dispatcher.setAuthenticator(authenticator);
   return this;
 };

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -141,7 +141,7 @@ Dispatcher.prototype.dispatch = function(params, dispatchOptions) {
               error instanceof (errors.NoAuthorization)) {
             // Maybe attempt to retry unauthorized requests after getting
             // a new access token.
-            Bluebird.resolve(me.handleUnauthorized()).then(function(reauth) {
+            me.handleUnauthorized().then(function(reauth) {
               if (reauth) {
                 doRequest();
               } else {

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -141,7 +141,7 @@ Dispatcher.prototype.dispatch = function(params, dispatchOptions) {
               error instanceof (errors.NoAuthorization)) {
             // Maybe attempt to retry unauthorized requests after getting
             // a new access token.
-            me.handleUnauthorized().then(function(reauth) {
+            Bluebird.resolve(me.handleUnauthorized()).then(function(reauth) {
               if (reauth) {
                 doRequest();
               } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asana",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "A node.js client for the Asana API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When testing the automatic reauthorization with https://github.com/asana/node-asana-tester/,
I noticed a few bugs. The following changes make the reauthorization flow work correctly
with BrowserFlow:

- Use `this.establishCredentials`, not `this.ensureCredentials` (which doesn't exist).
- Return a boolean in `refreshCredentials` for the flow case.
- In `client.useOauth`, if credentials exist, we still want to save the flow information.
  Otherwise, we won't be able to re-authorize as expected.