### PR TITLE
A clearer example on how to pass both an access and a refresh token t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,22 @@ client.useOauth({
   credentials: credentials
 });
 ```
-
 See `examples/oauth/webserver` for a working example of this.
+
+##### To enable token auto refresh by the client object
+The 'useOauth' method can accept a single string argument which is an access token, or a credentiails object, to support auto refresh when your access token expires:
+
+```js
+var credentials = {
+  access_token: 'my_access_token'
+  refresh_token: 'my_refresh_token'
+};
+client.useOauth({
+  credentials: credentials
+});
+
+
+
 
 ### Collections
 


### PR DESCRIPTION
Working example when passing an access_token and a refresh_token to the client object - 
After looking into the dispatcher code, I see there's a check for the type of the passed argument.
For ease of use and getting started quickly,I would like to suggest this example to be included in the readme file