### PR TITLE
Fetching collection on route without pagination cause error.

### DIFF
--- a/lib/util/collection.js
+++ b/lib/util/collection.js
@@ -96,6 +96,17 @@ Collection.prototype.nextPage = function() {
   }
 };
 
+/**
+ * Checks if Collection can fetch next page
+ * @returns {boolean}
+ */
+Collection.prototype.isPaginateable  = function () {
+  /* jshint camelcase:false */
+  var me = this;
+  var next = me._response.next_page;
+  return typeof(next) === 'object' || next === null;
+};
+
 
 /**
  * Get remaining results from a collection request, transparently
@@ -113,7 +124,7 @@ Collection.prototype.fetch = function(maxItems) {
     var results = [];
 
     function fetch(collection) {
-      if (collection === null) {
+      if (collection === null || !me.isPaginateable()) {
         // Reached end of pages.
         resolve(results);
       } else {


### PR DESCRIPTION
For some of API`s routes are not available pagination. Fetching collection on this routes cause error, but I think it better to return value.