### PR TITLE
Support collection results with no page info

### DIFF
--- a/lib/util/collection.js
+++ b/lib/util/collection.js
@@ -75,10 +75,7 @@ Collection.prototype.nextPage = function() {
   /* jshint camelcase:false */
   var me = this;
   var next = me._response.next_page;
-  if (next === null) {
-    // No more results.
-    return Bluebird.resolve(null);
-  } else if (typeof(next) === 'object') {
+  if (typeof(next) === 'object' && next !== null) {
     var url = next.uri;
     return Collection.fromDispatch(
         me._dispatcher.dispatch({
@@ -89,10 +86,8 @@ Collection.prototype.nextPage = function() {
         me._dispatcher,
         me._dispatchOptions);
   } else {
-    // We got a successful response back but it did not appear to contain
-    // an array of items. So maybe we did not fetch a collection.
-    throw new Error(
-        'Cannot fetch next page of response that does not have paging info');
+    // No more results.
+    return Bluebird.resolve(null);
   }
 };
 

--- a/test/util/collection_spec.js
+++ b/test/util/collection_spec.js
@@ -76,6 +76,20 @@ describe('Collection', function() {
       });
     });
 
+    it('should resolve to null if no page info', function(done) {
+      var response = {
+        'data': [{ id: 123 }]
+      };
+      var dispatcher = {
+        dispatch: sinon.stub()
+      };
+      var collection = new Collection(response, dispatcher);
+      collection.nextPage().then(function(page) {
+        assert.equal(page, null);
+        done();
+      });
+    });
+
     it('should make request and return collection for page', function(done) {
       var response = {
         'data': ['abc'],


### PR DESCRIPTION
Since for some endpoints the API does not paginate and in those cases does not return page info (though it should).