### PR TITLE
Fix issue with infinite loop in streaming.

### DIFF
--- a/lib/util/buffered_readable.js
+++ b/lib/util/buffered_readable.js
@@ -31,7 +31,7 @@ BufferedReadable.prototype._read = function() {
   if (this._buffer.length > 0) {
     for (var i = 0; i < this._buffer.length; i++) {
       if (!this.push(this._buffer[i])) {
-        this._buffer = this._buffer.slice(i);
+        this._buffer = this._buffer.slice(i + 1);
         return;
       }
     }

--- a/test/util/buffered_readable_spec.js
+++ b/test/util/buffered_readable_spec.js
@@ -50,7 +50,7 @@ describe('BufferedReadable', function() {
       assert(stream.push.calledTwice);
       assert.equal(stream.push.firstCall.args[0], 'abc');
       assert.equal(stream.push.secondCall.args[0], 'def');
-      assert.deepEqual(stream._buffer, ['def']);
+      assert.deepEqual(stream._buffer, []);
     });
 
     it('should drain buffer then call readUnbuffered', function() {


### PR DESCRIPTION
This issue was affecting newer versions of node, but it was working fine in a very old version of node.

Streaming would show about first 15 items and then thereafter infinitely loop on the next item.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/182694763554707/293757317680545)
