### PR TITLE
Listen to internal credentials auto-refresh via callback

### DIFF
--- a/lib/auth/oauth_authenticator.js
+++ b/lib/auth/oauth_authenticator.js
@@ -27,6 +27,7 @@ function OauthAuthenticator(options) {
   }
   this.flow = options.flow || null;
   this.app = options.app;
+  this.refreshCredentialsCallback = options.refreshCredentialsCallback || null;
 }
 
 util.inherits(OauthAuthenticator, Authenticator);
@@ -94,12 +95,18 @@ OauthAuthenticator.prototype.refreshCredentials = function() {
       var refreshToken = me.credentials.refresh_token;
       me.refreshPromise = me.app.accessTokenFromRefreshToken(refreshToken).then(
           function(credentials) {
+
             // Update credentials, but hang on to refresh token.
             if (!credentials.refresh_token) {
               credentials.refresh_token = refreshToken;
             }
             me.credentials = credentials;
             me.refreshPromise = null;
+
+            if (me.refreshCredentialsCallback !== null) {
+              me.refreshCredentialsCallback(me.credentials);
+            }
+
             return true;
           });
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -133,7 +133,14 @@ Client.prototype.useAccessToken = function(accessToken) {
  * @option {Object} [credentials] Credentials to use; no flow required to
  *     obtain authorization. This object should at a minimum contain an
  *     `access_token` string field.
- * @return {Client}               this
+ * @option {Function} [refreshCredentialsCallback] An optional callback
+ *    function to execute once the authenticator auto refreshes
+ *    access credentials.
+ *    For Example: 
+ *    function(credentials){
+ *      console.log("Your new credentials are:"+credentials)
+ *    }
+ * @return {Client} this
  */
 Client.prototype.useOauth = function(options) {
   options = options || {};
@@ -148,7 +155,8 @@ Client.prototype.useOauth = function(options) {
   var authenticator = new OauthAuthenticator({
     app: this.app,
     credentials: options.credentials,
-    flow: flow
+    flow: flow,
+    refreshCredentialsCallback: options.refreshCredentialsCallback || null
   });
 
   this.dispatcher.setAuthenticator(authenticator);


### PR DESCRIPTION
After submitting a question to api-support and currently awaiting an
official answer from Jerrin and Ceri… I have decided to add this
functionality myself and submit it as a pull request. Please consider
adding it to the main code base.

Change details:
————————
It is now possible to pass an (optional) callback when instantiating a
new asana client instance. the callback is triggered once the client
internally refreshes credentials, allowing the implementing code to
“listen” to credentials changes and update it’s own variables/stored
credentials.
This saves time during additional request performed by new instances of
the Asana client, as there’s no need to re-authenticate every single
time, to get a valid access token.

Example:
—————————
var asana = require('asana');
var client = asana.Client.create({
clientId: 270…,
clientSecret: "720abc…..”,
redirectUri:  "https://some.url.com/oauth/asana",
});
client.useOauth({
credentials: credentials,
refreshCredentialsCallback: function(credentials){
console.log(credentials);
}
});

This can also be used inside a class/object by binding “this” to the
callback:
——————————
client.useOauth({
credentials: credentials,
refreshCredentialsCallback: function(credentials){
this.myInstanceMethod(credentials)
}.bind(this)
});

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/182694763554707/346544214941438)
