### PR TITLE
Listen to internal re-authentication via passing callback to OAuthAuhenticator

### DIFF
--- a/lib/auth/oauth_authenticator.js
+++ b/lib/auth/oauth_authenticator.js
@@ -103,7 +103,7 @@ OauthAuthenticator.prototype.refreshCredentials = function() {
             me.credentials = credentials;
             me.refreshPromise = null;
 
-            if (me.refreshCredentialsCallback != null) {
+            if (me.refreshCredentialsCallback !== null) {
               me.refreshCredentialsCallback(me.credentials);
             }
 

--- a/lib/auth/oauth_authenticator.js
+++ b/lib/auth/oauth_authenticator.js
@@ -27,6 +27,7 @@ function OauthAuthenticator(options) {
   }
   this.flow = options.flow || null;
   this.app = options.app;
+  this.refreshCredentialsCallback = options.refreshCredentialsCallback || null;
 }
 
 util.inherits(OauthAuthenticator, Authenticator);
@@ -94,12 +95,18 @@ OauthAuthenticator.prototype.refreshCredentials = function() {
       var refreshToken = me.credentials.refresh_token;
       me.refreshPromise = me.app.accessTokenFromRefreshToken(refreshToken).then(
           function(credentials) {
+
             // Update credentials, but hang on to refresh token.
             if (!credentials.refresh_token) {
               credentials.refresh_token = refreshToken;
             }
             me.credentials = credentials;
             me.refreshPromise = null;
+
+            if (me.refreshCredentialsCallback != null) {
+              me.refreshCredentialsCallback(me.credentials);
+            }
+
             return true;
           });
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -136,7 +136,10 @@ Client.prototype.useAccessToken = function(accessToken) {
  * @option {Function} [refreshCredentialsCallback] An optional callback
  *    function to execute once the authenticator auto refreshes
  *    access credentials.
- *    For Example: function(credentials){console.log("Your new credentials are:"+credentials)}
+ *    For Example: 
+ *    function(credentials){
+ *     console.log("Your new credentials are:"+credentials)
+ *    }
  * @return {Client}       this
  */
 Client.prototype.useOauth = function(options) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -133,7 +133,11 @@ Client.prototype.useAccessToken = function(accessToken) {
  * @option {Object} [credentials] Credentials to use; no flow required to
  *     obtain authorization. This object should at a minimum contain an
  *     `access_token` string field.
- * @return {Client}               this
+ * @option {Function} [refreshCredentialsCallback] An optional callback
+ *    function to execute once the authenticator auto refreshes
+ *    access credentials.
+ *    For Example: function(credentials){console.log("Your new credentials are:"+credentials)}
+ * @return {Client}       this
  */
 Client.prototype.useOauth = function(options) {
   options = options || {};
@@ -148,7 +152,8 @@ Client.prototype.useOauth = function(options) {
   var authenticator = new OauthAuthenticator({
     app: this.app,
     credentials: options.credentials,
-    flow: flow
+    flow: flow,
+    refreshCredentialsCallback: options.refreshCredentialsCallback || null
   });
 
   this.dispatcher.setAuthenticator(authenticator);


### PR DESCRIPTION
`client.useOauth({
		credentials: <credentials>,
		refreshCredentialsCallback: function(credentials){
			console.log(credentials);
		}
	});`

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/182694763554707/346546712411356)
