### PR TITLE
New feature: change error configurations

### DIFF
--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -6,13 +6,21 @@ var querystring = require('querystring');
 
 var VERSION = require('../package.json').version;
 
-var STATUS_MAP = Object.keys(errors).reduce(function(map, key) {
-  var error = new errors[key](null);
-  if (error.status) {
-    map[error.status] = errors[key];
-  }
-  return map;
-}, {});
+var STATUS_MAP = null;
+
+setTimeout(function() {
+  STATUS_MAP = Object.keys(errors).reduce(function(map, key) {
+    if (key === 'config') {
+      return map;
+    }
+    var args = errors.config[key];
+    var error = new errors[key](args);
+    if (error.status) {
+      map[error.status] = errors[key];
+    }
+    return map;
+  }, {});
+}, 0);
 
 // TODO: Provide same set of options for each request as for configuration,
 // so the config at construction time is just the "defaults"

--- a/lib/errors/config.js
+++ b/lib/errors/config.js
@@ -1,0 +1,34 @@
+const config = {};
+
+config.Forbidden = null;
+
+config.InvalidRequest = null;
+
+config.NoAuthorization = null;
+
+config.NotFound = null;
+
+config.PremiumOnly = null;
+
+config.RateLimitEnforced = {
+  // retryAfterSeconds
+  retry_after: 2,
+};
+
+config.ServerError = null;
+
+// set full configuration for error
+config.setConfig = function(error_name, error_config) {
+  this[error_name] = error_config;
+};
+
+// add single configuration for error
+config.addConfig = function(error_name, single_config_name, single_config) {
+  if (!this[error_name]) {
+    this[error_name] = {};
+  }
+
+  this[error_name][single_config_name] = single_config;
+};
+
+module.exports = config;

--- a/lib/errors/config.js
+++ b/lib/errors/config.js
@@ -10,10 +10,7 @@ config.NotFound = null;
 
 config.PremiumOnly = null;
 
-config.RateLimitEnforced = {
-  // retryAfterSeconds
-  retry_after: 2,
-};
+config.RateLimitEnforced = null;
 
 config.ServerError = null;
 

--- a/lib/errors/config.js
+++ b/lib/errors/config.js
@@ -14,18 +14,13 @@ config.RateLimitEnforced = null;
 
 config.ServerError = null;
 
-// set full configuration for error
 config.setConfig = function(errorName, errorConfig) {
-  this[errorName] = errorConfig;
-};
-
-// add single configuration for error
-config.addConfig = function(errorName, singleConfigName, singleConfig) {
   if (!this[errorName]) {
-    this[errorName] = {};
+    config[errorName] = {};
   }
-
-  this[errorName][singleConfigName] = singleConfig;
+  Object.keys(errorConfig, function(errorKey) {
+    config[errorKey] = errorConfig[errorKey];
+  });
 };
 
 module.exports = config;

--- a/lib/errors/config.js
+++ b/lib/errors/config.js
@@ -1,4 +1,4 @@
-const config = {};
+var config = {};
 
 config.Forbidden = null;
 
@@ -18,17 +18,17 @@ config.RateLimitEnforced = {
 config.ServerError = null;
 
 // set full configuration for error
-config.setConfig = function(error_name, error_config) {
-  this[error_name] = error_config;
+config.setConfig = function(errorName, errorConfig) {
+  this[errorName] = errorConfig;
 };
 
 // add single configuration for error
-config.addConfig = function(error_name, single_config_name, single_config) {
-  if (!this[error_name]) {
-    this[error_name] = {};
+config.addConfig = function(errorName, singleConfigName, singleConfig) {
+  if (!this[errorName]) {
+    this[errorName] = {};
   }
 
-  this[error_name][single_config_name] = single_config;
+  this[errorName][singleConfigName] = singleConfig;
 };
 
 module.exports = config;

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -1,3 +1,5 @@
+exports.config = require('./config');
+
 exports.Forbidden = require('./forbidden');
 exports.InvalidRequest = require('./invalid_request');
 exports.NoAuthorization = require('./no_authorization');

--- a/lib/errors/rate_limit_enforced.js
+++ b/lib/errors/rate_limit_enforced.js
@@ -6,6 +6,7 @@ function RateLimitEnforced(value) {
   AsanaError.call(this, 'Rate Limit Enforced');
   this.status = 429;
   this.value = value;
+
   this.retryAfterSeconds = value && parseInt(value.retry_after, 10);
 }
 

--- a/test/dispatcher_spec.js
+++ b/test/dispatcher_spec.js
@@ -169,6 +169,9 @@ describe('Dispatcher', function() {
     });
 
     Object.keys(errors).forEach(function(key) {
+      if (key === 'config') {
+        return;
+      }
       it('should create an error for ' + key, function() {
         var request = sinon.stub();
         var err = new errors[key]();


### PR DESCRIPTION
Sometimes we need change configuration of errors.

For example, I need to change `retryAfterSeconds` value.

Now you can do it like this:

```js
const asana = require('asana');
asana.errors.config.setConfig('RateLimitEnforced', { retry_after: 3 }); // second
```

All configurations should be added at first, before any actions.