### PR TITLE
Added support for HTTP proxy via dispatcher options

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -196,7 +196,8 @@ Client.create = function(options) {
       new Dispatcher({
         asanaBaseUrl: options.asanaBaseUrl,
         timeout: options.requestTimeout,
-        defaultHeaders: options.defaultHeaders
+        defaultHeaders: options.defaultHeaders,
+	defaultProxy: options.defaultProxy
       }),
       options);
 };

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -76,6 +76,13 @@ function Dispatcher(options) {
    * @type {Number}
    */
   this.requestTimeout = options.requestTimeout || null;
+
+  /**
+   * What proxy should be used by default in all requests, if any.
+   * Can be overridden by individual requests.
+   * @type {String}
+   */
+  this.defaultProxy = options.defaultProxy || null;
 }
 
 /**
@@ -143,6 +150,10 @@ Dispatcher.prototype.dispatch = function(params, dispatchOptions) {
 
   if (this.requestTimeout) {
     params.timeout = this.requestTimeout;
+  }
+
+  if (this.defaultProxy) {
+    params.proxy = this.defaultProxy;
   }
 
   return new Bluebird(function(resolve, reject) {


### PR DESCRIPTION
As per the issue:
No provision for specifying HTTP proxy for machines behind firewall #121

I require proxy functionality and would appreciate, if my modifications could be added to the master.