### PR TITLE
Add request params to the events get method

### DIFF
--- a/lib/resources/events.js
+++ b/lib/resources/events.js
@@ -6,7 +6,7 @@ var Events = require('./gen/events');
  * changes to a resource.
  * @param  {Number} resourceId  The id of the resource to get events for
  * @param  {String} [syncToken] Token from a previous sync, if any
- * @param {Object} [params] Parameters for the request
+ * @param  {Object} [params] Parameters for the request
  * @return {Promise}            The result of the API call:
  *     {String} sync     The new sync token to use for the next request
  *     {Object[]} [data] The changes on the resource since the last sync,

--- a/lib/resources/events.js
+++ b/lib/resources/events.js
@@ -6,19 +6,19 @@ var Events = require('./gen/events');
  * changes to a resource.
  * @param  {Number} resourceId  The id of the resource to get events for
  * @param  {String} [syncToken] Token from a previous sync, if any
+ * @param {Object} [params] Parameters for the request
  * @return {Promise}            The result of the API call:
  *     {String} sync     The new sync token to use for the next request
  *     {Object[]} [data] The changes on the resource since the last sync,
  *                       may not exist if sync token is new.
  */
-Events.prototype.get = function(resourceId, syncToken) {
-  var params = {
-    resource: resourceId
-  };
+Events.prototype.get = function(resourceId, syncToken, params) {
+  var requestParams = params || {};
+  requestParams.resource = resourceId;
   if (syncToken) {
-    params.sync = syncToken;
+    requestParams.sync = syncToken;
   }
-  return this.dispatcher.get('/events', params);
+  return this.dispatcher.get('/events', requestParams);
 };
 
 /**

--- a/lib/resources/events.js
+++ b/lib/resources/events.js
@@ -6,21 +6,19 @@ var Events = require('./gen/events');
  * changes to a resource.
  * @param  {Number} resourceId  The id of the resource to get events for
  * @param  {String} [syncToken] Token from a previous sync, if any
- * @param {Object} [params] Parameters for the request
+ * @param  {Object} [params] Parameters for the request
  * @return {Promise}            The result of the API call:
  *     {String} sync     The new sync token to use for the next request
  *     {Object[]} [data] The changes on the resource since the last sync,
  *                       may not exist if sync token is new.
  */
-Events.prototype.get = function(resourceId, syncToken, params) {
-  var requestParams = params || {};
-  requestParams.resource = resourceId;
+Events.prototype.get = function(resourceId, syncToken, params = {}) {
+  params.resource = resourceId;
   if (syncToken) {
-    requestParams.sync = syncToken;
+    params.sync = syncToken;
   }
-  return this.dispatcher.get('/events', requestParams);
+  return this.dispatcher.get('/events', params);
 };
-
 /**
  * Begins polling the /events endpoint of the API to listen to changes
  * to a resource.

--- a/lib/resources/events.js
+++ b/lib/resources/events.js
@@ -6,19 +6,21 @@ var Events = require('./gen/events');
  * changes to a resource.
  * @param  {Number} resourceId  The id of the resource to get events for
  * @param  {String} [syncToken] Token from a previous sync, if any
- * @param  {Object} [params] Parameters for the request
+ * @param {Object} [params] Parameters for the request
  * @return {Promise}            The result of the API call:
  *     {String} sync     The new sync token to use for the next request
  *     {Object[]} [data] The changes on the resource since the last sync,
  *                       may not exist if sync token is new.
  */
-Events.prototype.get = function(resourceId, syncToken, params = {}) {
-  params.resource = resourceId;
+Events.prototype.get = function(resourceId, syncToken, params) {
+  var requestParams = params || {};
+  requestParams.resource = resourceId;
   if (syncToken) {
-    params.sync = syncToken;
+    requestParams.sync = syncToken;
   }
-  return this.dispatcher.get('/events', params);
+  return this.dispatcher.get('/events', requestParams);
 };
+
 /**
  * Begins polling the /events endpoint of the API to listen to changes
  * to a resource.


### PR DESCRIPTION
Without this, we cannot specify `opt_expand` and `opt_fields`

[https://asana.com/developers/api-reference/events#](https://asana.com/developers/api-reference/events#)