### PR TITLE
Fix Rate Limit Handling

### DIFF
--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -260,7 +260,7 @@ Dispatcher.prototype.dispatch = function(params, dispatchOptions) {
         }
 
         if (STATUS_MAP[res.statusCode]) {
-          var error = new STATUS_MAP[res.statusCode](payload);
+          var error = new STATUS_MAP[res.statusCode](payload, res);
 
           if (me.retryOnRateLimit &&
               error instanceof (errors.RateLimitEnforced)) {

--- a/lib/errors/rate_limit_enforced.js
+++ b/lib/errors/rate_limit_enforced.js
@@ -1,12 +1,12 @@
 var util = require('util');
 var AsanaError = require('./error');
 
-function RateLimitEnforced(value) {
+function RateLimitEnforced(value, res) {
   /* jshint camelcase:false */
   AsanaError.call(this, 'Rate Limit Enforced');
   this.status = 429;
   this.value = value;
-  this.retryAfterSeconds = value && parseInt(value.retry_after, 10);
+  this.retryAfterSeconds = value && parseInt(value.retry_after || res.headers['retry-after'], 10);
 }
 
 util.inherits(RateLimitEnforced, Error);

--- a/lib/errors/rate_limit_enforced.js
+++ b/lib/errors/rate_limit_enforced.js
@@ -6,7 +6,10 @@ function RateLimitEnforced(value, res) {
   AsanaError.call(this, 'Rate Limit Enforced');
   this.status = 429;
   this.value = value;
-  this.retryAfterSeconds = value && parseInt(value.retry_after || res.headers['retry-after'], 10);
+  this.retryAfterSeconds = value && parseInt(
+    value.retry_after || res.headers['retry-after'],
+    10
+  );
 }
 
 util.inherits(RateLimitEnforced, Error);


### PR DESCRIPTION
The docs say the retry-after header will provide the number of seconds to backoff for. The payload.retry_after value is always undefined. This seems to have never been documented and probably was implicit behavior which was dependend upon.

https://developers.asana.com/docs/standard-rate-limits