### PR TITLE
Fix gulpfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,8 @@ See our [openapi spec][https://github.com/Asana/developer-docs/blob/master/defs/
 
   1. Merge in the desired changes into the `master` branch and commit them.
   2. Clone the repo; work on `master`.
-  3. Bump the package version to indicate the [semantic version](http://semver.org) change, using one of: `gulp bump-patch`, `gulp bump-feature`, or `gulp bump-release`
+  3. Bump the package version to indicate the [semantic version](http://semver.org) change, using one of: `gulp bump-patch`, `gulp bump-minor`, or `gulp bump-major`
+  (NOTE: If this is your first time running gulp please install `gulp` globall using `npm i -g gulp`)
   4. Push changes to origin, including tags:
      `git push origin master --tags` 
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,7 +51,7 @@ function browserTask(minify) {
 function ensureGitClean(done) {
   git.status(function(err, out) {
     if (err) { throw err; }
-    if (!/working directory clean/.exec(out)) {
+    if (!/nothing to commit/.exec(out)) {
       throw new Error('Git working directory not clean, will not bump version');
     }
   });
@@ -81,18 +81,10 @@ function bumpVersion(importance) {
       .pipe(filter('package.json'))
       .pipe(tagVersion());
 }
-function bumpPatch() {
-  return bumpVersion('patch');
-}
-gulp.task('bump-patch', gulp.series('ensure-git-clean', bumpPatch));
-function bumpFeature() {
-  return bumpVersion('minor');
-}
-gulp.task('bump-feature', gulp.series('ensure-git-clean', bumpFeature));
-function bumpVersion() {
-  return bumpVersion('major');
-}
-gulp.task('bump-release', gulp.series('ensure-git-clean', bumpVersion));
+
+gulp.task('bump-patch', gulp.series('ensure-git-clean', bumpVersion('patch')));
+gulp.task('bump-minor', gulp.series('ensure-git-clean', bumpVersion('minor')));
+gulp.task('bump-major', gulp.series('ensure-git-clean', bumpVersion('major')));
 
 /**
  * Lints all of the JavaScript files and fails if the tasks do not pass


### PR DESCRIPTION
- There was a circular dependency in the gulpfile because there were two functions with the same name `bumpVersion`
- Update naming of commands to be streamlined with semantic versioning (`major`, `minor`, `patch`)
- Update check for git status
- Update `README.md`