### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Run npm build and npm test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [8.x, 9.x, 12.x]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: npm i
+      - run: npm run build --if-present
+      - run: npm test

--- a/.github/workflows/publish-to-github-releases.yml
+++ b/.github/workflows/publish-to-github-releases.yml
@@ -1,0 +1,26 @@
+name: Publish to GitHub Releases
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build-n-publish-to-github:
+    name: Build and publish to GitHub Releases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '8.x'
+      - name: Bundle the code, full version to asana.js and minified to asana-min.js
+        run: |
+          npm i gulp
+          gulp bundle
+      - name: Publish to GitHub Releases
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/asana.js
+            dist/asana-min.js

--- a/.github/workflows/publish-to-npmjs.yml
+++ b/.github/workflows/publish-to-npmjs.yml
@@ -1,0 +1,21 @@
+name: Publish 📦 to npmjs
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build-n-publish-to-npmjs:
+    name: Build and publish 📦 to npmjs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '8.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm i
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Asana [![GitHub release][release-image]]() [![Build Status][travis-image]][travis-url] [![NPM Version][npm-image]][npm-url]
+# Asana [![GitHub release][release-image]]() [![Build Status][github-actions-image]][github-actions-url] [![NPM Version][npm-image]][npm-url]
 
 A JavaScript client (for both Node and browser) for the Asana API v1.0.
 
@@ -319,14 +319,15 @@ See our [openapi spec][https://github.com/Asana/developer-docs/blob/master/defs/
   3. Bump the package version to indicate the [semantic version](http://semver.org) change, using one of: `gulp bump-patch`, `gulp bump-minor`, or `gulp bump-major`
   (NOTE: If this is your first time running gulp please install `gulp` globall using `npm i -g gulp`)
   4. Push changes to origin, including tags:
-     `git push origin master --tags` 
+     `git push origin master --tags`
+  5. Edit/Update the release description on
 
-Travis CI will automatically build and deploy the tagged release.
+GitHub Actions will automatically build and deploy the tagged release.
 
 [release-image]: https://img.shields.io/github/release/asana/node-asana.svg
 
-[travis-url]: http://travis-ci.org/Asana/node-asana
-[travis-image]: http://img.shields.io/travis/Asana/node-asana.svg?style=flat-square&branch=master
+[github-actions-url]: https://github.com/Asana/node-asana/actions
+[github-actions-image]: https://github.com/Asana/node-asana/workflows/Build/badge.svg
 
 [npm-url]: https://www.npmjs.org/package/asana
 [npm-image]: http://img.shields.io/npm/v/asana.svg?style=flat-square

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -67,8 +67,8 @@ gulp.task('ensure-git-clean', ensureGitClean);
  * You can use the commands
  *
  *     gulp bump-patch     # makes v0.1.0 → v0.1.1
- *     gulp bump-feature   # makes v0.1.1 → v0.2.0
- *     gulp bump-release   # makes v0.2.1 → v1.0.0
+ *     gulp bump-minor   # makes v0.1.1 → v0.2.0
+ *     gulp bump-major   # makes v0.2.1 → v1.0.0
  *
  * To bump the version numbers accordingly after you did a patch,
  * introduced a feature or made a backwards-incompatible release.
@@ -81,10 +81,18 @@ function bumpVersion(importance) {
       .pipe(filter('package.json'))
       .pipe(tagVersion());
 }
-
-gulp.task('bump-patch', gulp.series('ensure-git-clean', bumpVersion('patch')));
-gulp.task('bump-minor', gulp.series('ensure-git-clean', bumpVersion('minor')));
-gulp.task('bump-major', gulp.series('ensure-git-clean', bumpVersion('major')));
+function bumpPatch() {
+  return bumpVersion('patch');
+}
+gulp.task('bump-patch', gulp.series('ensure-git-clean', bumpPatch));
+function bumpMinor() {
+  return bumpVersion('minor');
+}
+gulp.task('bump-minor', gulp.series('ensure-git-clean', bumpMinor));
+function bumpMajor() {
+  return bumpVersion('major');
+}
+gulp.task('bump-major', gulp.series('ensure-git-clean', bumpMajor));
 
 /**
  * Lints all of the JavaScript files and fails if the tasks do not pass


### PR DESCRIPTION
- Added `build.yml` workflow to build and test on node 8.x, 9.x, 12.x
- Added `publish-to-github-releases` workflow to release to GitHub Releases
- Added `publish-to-github-npmjs` workflow to release to NPM package manager
- Update `README.md` to remove travis build badge and add new build badge for GitHub Actions. Will fully remove Travis CI in another PR.