### PR TITLE
Update npmjs publish workflow registry url

### DIFF
--- a/.github/workflows/publish-to-npmjs.yml
+++ b/.github/workflows/publish-to-npmjs.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '8.x'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: 'https://registry.npmjs.com'
       - run: npm i
       - run: npm publish
         env:


### PR DESCRIPTION
- Update the npmjs registry url from `https://registry.npmjs.org` to `https://registry.npmjs.com`