### PR TITLE
Remove AWS auth from publish npm step

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -79,11 +79,6 @@ jobs:
     name: Build and publish 📦 to npmjs
     runs-on: ubuntu-latest
     steps:
-      - name: Authenticate to AWS
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: us-east-1
-          role-to-assume: arn:aws:iam::403483446840:role/autogen_github_actions_beta_release_asana_node_client_library
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
### TL;DR

Removed AWS authentication step from the npm publish workflow.

### What changed?

Removed the "Authenticate to AWS" step from the GitHub Actions workflow that publishes packages to npmjs. This step was using the AWS credentials configuration action and assuming a specific IAM role which we don't need since we switched to Trusted Publishing.
