### PR TITLE
Upgrade node for publshing steps

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -85,7 +85,7 @@ jobs:
           ref: master
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
       - name: Build distribution
         run: |
@@ -115,8 +115,8 @@ jobs:
           ref: master
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
-          registry-url: "https://registry.npmjs.com"
+          node-version: "24.x"
+          registry-url: "https://registry.npmjs.org"
       - name: Build distribution
         run: |
           npm pkg set 'main'='dist/index.js'


### PR DESCRIPTION
### TL;DR

Update Node.js version from 18.x to 24.x in GitHub Actions workflows and fix NPM registry URL.

### What changed?

- Updated Node.js version from 18.x to 24.x in two GitHub Actions workflow jobs
- Fixed NPM registry URL from `registry.npmjs.com` to `registry.npmjs.org` in one of the workflow jobs

### Explanation
Fix npm publish by upgrading to Node 24.x for trusted publishing support

After migrating from token-based authentication to npm trusted publishing (OIDC), the publish-to-npmjs job was failing with 404 Not Found / "Access token expired or revoked".

The root cause was that Node 18.x ships with npm ~9.x, but trusted publishing requires npm >= 11.5.1 for OIDC auto-detection. Without it, npm falls back to traditional token auth, finds an empty NODE_AUTH_TOKEN (since the AWS Secrets Manager step was removed), and fails.

Changes:
- Upgraded node-version from 18.x to 24.x in publish-to-npmjs and publish-to-github-releases jobs (Node 24.x ships with npm 11.x which supports OIDC-based trusted publishing)
- Fixed registry URL typo in publish-to-github-releases (registry.npmjs.com -> registry.npmjs.org)
