### PR TITLE
Move @babel/cli from dependencies to devDependencies

### DIFF
--- a/codegen/templates/package.mustache
+++ b/codegen/templates/package.mustache
@@ -16,10 +16,10 @@
     "fs": false
   },
   "dependencies": {
-    "@babel/cli": "^7.0.0",
     "superagent": "^6.1.0"
   },
   "devDependencies": {
+    "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-decorators": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "fs": false
   },
   "dependencies": {
-    "@babel/cli": "^7.0.0",
     "superagent": "^6.1.0"
   },
   "devDependencies": {
+    "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-decorators": "^7.0.0",


### PR DESCRIPTION
## Summary

- Moves `@babel/cli` from `dependencies` to `devDependencies`
- `@babel/cli` is a build tool not imported at runtime by any source in `src/`
- Having it in `dependencies` forces all consumers to install `@babel/cli` → `glob` → `minimatch`, which carries 4 high-severity ReDoS vulnerabilities ([GHSA-3ppc-4f35-3m26](https://github.com/advisories/GHSA-3ppc-4f35-3m26))
- This change eliminates those vulnerabilities for downstream consumers with zero runtime impact

## Test plan

- [ ] Verify `npm test` still passes (babel is still available via devDependencies)
- [ ] Verify `npm audit` shows 0 high-severity vulnerabilities for a fresh consumer install